### PR TITLE
fix panic bug and add logging capability

### DIFF
--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.12.1] - unreleased
+
+### FIXED
+
+- return a stream error when panicking while downloading
+- return a strem error when panicking while retrying
+
+### ADDED
+
+- add a function to `Reporter` trait to track panics
+- documentation
+- `FailingClientSimulator` can panic while streaming
+- Display for `BytesHint`
+
+### CHANGED
+
+- `FailingClientSimulator` does stream errors based on the requested range
+
+### REMOVED
+
+- location method from `Reporter` trait. Use constructor to set a location.
 
 ## [0.12.0] - 2022-01-19
 

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### FIXED
 
 - return a stream error when panicking while downloading
-- return a strem error when panicking while retrying
+- return a stream error when panicking while retrying
 
 ### ADDED
 
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - documentation
 - `FailingClientSimulator` can panic while streaming
 - Display for `BytesHint`
+- Logging via the `Reporter` trait
 
 ### CHANGED
 

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_core"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -53,6 +53,7 @@ mod download_range;
 mod download_session;
 mod downloader;
 pub mod errors;
+pub mod logging;
 mod machinery;
 pub mod reader;
 pub mod reporter;

--- a/condow_core/src/logging.rs
+++ b/condow_core/src/logging.rs
@@ -1,0 +1,427 @@
+//! Reporters which do logging
+
+use std::{fmt, sync::Arc};
+
+use super::{Reporter, ReporterFactory};
+
+/// A logger logging on events send to a [Reporter]
+///
+/// `Logger` implements [Reporter]. Therefore reporting
+/// must be enabled. This can be done by directly passing
+/// an instance to a download method that accepts a reporter
+/// or by setting the [ReporterFactory] of one of the downloaders.
+/// To ensure logging for all downloads using a [DownloadSession]
+/// with the [LoggerFactory] as a [ReporterFactory] is recommended.
+///
+/// [DownloadSession]: crate::DownloadSession
+#[derive(Clone)]
+pub struct Logger {
+    location: Option<Arc<String>>,
+    inner: Inner,
+}
+
+impl Logger {
+    /// Create a new instance by giving callbacks for various log levels
+    ///
+    /// Setting `None` disables logging on that level.
+    ///
+    /// The callbacks are called on the same thread as the downloading operation and
+    /// therefore should be quick and non blocking.
+    pub fn create(
+        on_debug: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+        on_info: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+        on_warn: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+        on_error: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    ) -> Self {
+        Self {
+            location: None,
+            inner: Inner {
+                on_debug,
+                on_info,
+                on_warn,
+                on_error,
+            },
+        }
+    }
+
+    /// Log a debug message
+    pub fn debug(&self, msg: fmt::Arguments) {
+        self.inner
+            .on_debug
+            .as_deref()
+            .into_iter()
+            .for_each(|f| f(self.location(), msg));
+    }
+
+    /// Log an info message
+    pub fn info(&self, msg: fmt::Arguments) {
+        self.inner
+            .on_info
+            .as_deref()
+            .into_iter()
+            .for_each(|f| f(self.location(), msg));
+    }
+
+    /// Log a warning message
+    pub fn warn(&self, msg: fmt::Arguments) {
+        self.inner
+            .on_warn
+            .as_deref()
+            .into_iter()
+            .for_each(|f| f(self.location(), msg));
+    }
+
+    /// Log an error message
+    pub fn error(&self, msg: fmt::Arguments) {
+        self.inner
+            .on_error
+            .as_deref()
+            .into_iter()
+            .for_each(|f| f(self.location(), msg));
+    }
+
+    /// The location of the download this reporter is referring to
+    pub fn location(&self) -> &str {
+        match self.location.as_ref() {
+            Some(l) => &l,
+            None => "<unknown>",
+        }
+    }
+}
+
+impl Reporter for Logger {
+    fn effective_range(&self, _range: crate::InclusiveRange) {}
+
+    fn download_started(&self) {
+        self.info(format_args!("Download started"));
+    }
+
+    fn download_completed(&self, _time: std::time::Duration) {
+        self.info(format_args!("Download completed"));
+    }
+
+    fn download_failed(&self, _time: Option<std::time::Duration>) {
+        self.error(format_args!("Download failed"));
+    }
+
+    fn retry_attempt(
+        &self,
+        _location: &dyn fmt::Display,
+        error: &crate::errors::CondowError,
+        next_in: std::time::Duration,
+    ) {
+        self.warn(format_args!("retry in {:?} on error '{}'", next_in, error));
+    }
+
+    fn stream_resume_attempt(
+        &self,
+        _location: &dyn fmt::Display,
+        error: &crate::errors::IoError,
+        orig_range: crate::InclusiveRange,
+        remaining_range: crate::InclusiveRange,
+    ) {
+        self.warn(format_args!(
+            "stream resume attempt for remaining \
+        range {} on range {} on error '{}'",
+            error, orig_range, remaining_range
+        ));
+    }
+
+    fn panic_detected(&self, msg: &str) {
+        self.warn(format_args!("panic detected '{}'", msg));
+    }
+
+    fn queue_full(&self) {}
+
+    fn chunk_completed(
+        &self,
+        _part_index: u64,
+        _chunk_index: usize,
+        _n_bytes: usize,
+        _time: std::time::Duration,
+    ) {
+    }
+
+    fn part_started(&self, part_index: u64, range: crate::InclusiveRange) {
+        self.debug(format_args!(
+            "Download of part {} ({}) started",
+            part_index, range
+        ));
+    }
+
+    fn part_completed(
+        &self,
+        part_index: u64,
+        n_chunks: usize,
+        n_bytes: u64,
+        time: std::time::Duration,
+    ) {
+        self.debug(format_args!(
+            "Download of part {} ({} bytes, {} chunks, time: {:?}) finished",
+            part_index, n_bytes, n_chunks, time
+        ));
+    }
+}
+
+/// A builder for a [LoggerFactory]
+#[derive(Default)]
+pub struct LoggerFactoryBuilder {
+    on_debug: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_info: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_warn: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_error: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+}
+
+impl LoggerFactoryBuilder {
+    /// Set a shared dynamic callback for logging debug messages
+    pub fn on_debug_dyn(
+        mut self,
+        on_debug: Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>,
+    ) -> Self {
+        self.on_debug = Some(on_debug);
+        self
+    }
+
+    /// Set a callback for logging debug messages
+    pub fn on_debug<F>(self, on_debug: F) -> Self
+    where
+        F: Fn(&str, fmt::Arguments) + Send + Sync + 'static,
+    {
+        self.on_debug_dyn(Arc::new(on_debug))
+    }
+
+    /// Set a shared dynamic callback for logging info messages
+    pub fn on_info_dyn(
+        mut self,
+        on_info: Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>,
+    ) -> Self {
+        self.on_info = Some(on_info);
+        self
+    }
+
+    /// Set a callback for logging info messages
+    pub fn on_info<F>(self, on_info: F) -> Self
+    where
+        F: Fn(&str, fmt::Arguments) + Send + Sync + 'static,
+    {
+        self.on_info_dyn(Arc::new(on_info))
+    }
+
+    /// Set a shared dynamic callback for logging warning messages
+    pub fn on_warn_dyn(
+        mut self,
+        on_warn: Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>,
+    ) -> Self {
+        self.on_warn = Some(on_warn);
+        self
+    }
+
+    /// Set a callback for logging warning messages
+    pub fn on_warn<F>(self, on_warn: F) -> Self
+    where
+        F: Fn(&str, fmt::Arguments) + Send + Sync + 'static,
+    {
+        self.on_warn_dyn(Arc::new(on_warn))
+    }
+
+    /// Set a shared dynamic callback for logging error messages
+    pub fn on_error_dyn(
+        mut self,
+        on_error: Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>,
+    ) -> Self {
+        self.on_error = Some(on_error);
+        self
+    }
+
+    /// Set a callback for logging error messages
+    pub fn on_error<F>(self, on_error: F) -> Self
+    where
+        F: Fn(&str, fmt::Arguments) + Send + Sync + 'static,
+    {
+        self.on_debug_dyn(Arc::new(on_error))
+    }
+
+    /// Returns a [StdOutConfigurator] to configure a default logging format
+    /// printed on stdout.
+    pub fn std_out(self) -> StdOutConfigurator {
+        StdOutConfigurator { builder: self }
+    }
+
+    /// Returns a [StdErrConfigurator] to configure a default logging format
+    /// printed on stderr.
+    pub fn std_err(self) -> StdErrConfigurator {
+        StdErrConfigurator { builder: self }
+    }
+
+    /// Create the logging factory
+    pub fn finish(self) -> LoggerFactory {
+        LoggerFactory {
+            inner: Inner {
+                on_debug: self.on_debug,
+                on_info: self.on_info,
+                on_warn: self.on_warn,
+                on_error: self.on_error,
+            },
+        }
+    }
+}
+
+/// Configure preformatted logging to stdout
+pub struct StdOutConfigurator {
+    builder: LoggerFactoryBuilder,
+}
+
+impl StdOutConfigurator {
+    /// Enable debug logging on stdout
+    pub fn debug(mut self) -> Self {
+        self.builder = self.builder.on_debug(|loc, msg| {
+            println!("{:5}|{}|{}", "DEBUG", loc, msg);
+        });
+        self
+    }
+
+    /// Enable info logging on stdout
+    pub fn info(mut self) -> Self {
+        self.builder = self.builder.on_info(|loc, msg| {
+            println!("{:5}|{}|{}", "INFO", loc, msg);
+        });
+        self
+    }
+
+    /// Enable warning logging on stdout
+    pub fn warn(mut self) -> Self {
+        self.builder = self.builder.on_warn(|loc, msg| {
+            println!("{:5}|{}|{}", "WARN", loc, msg);
+        });
+        self
+    }
+
+    /// Enable error logging on stdout
+    pub fn error(mut self) -> Self {
+        self.builder = self.builder.on_error(|loc, msg| {
+            println!("{:5}|{}|{}", "ERROR", loc, msg);
+        });
+        self
+    }
+
+    /// Enable warn and error logging on stdout
+    pub fn warn_error(self) -> Self {
+        self.warn().error()
+    }
+
+    /// Enable info, warn and error logging on stdout
+    pub fn info_warn_error(self) -> Self {
+        self.info().warn().error()
+    }
+
+    /// Enable debug, info, warn and error logging on stdout
+    pub fn all(self) -> Self {
+        self.debug().info().warn().error()
+    }
+
+    /// Get back to the [LoggerFactoryBuilder]
+    pub fn done(self) -> LoggerFactoryBuilder {
+        self.builder
+    }
+
+    /// Build the [LoggerFactory]
+    pub fn finish(self) -> LoggerFactory {
+        self.builder.finish()
+    }
+}
+
+/// Configure preformatted logging to stderr
+pub struct StdErrConfigurator {
+    builder: LoggerFactoryBuilder,
+}
+
+impl StdErrConfigurator {
+    /// Enable debug logging on stderr
+    pub fn debug(mut self) -> Self {
+        self.builder = self.builder.on_debug(|loc, msg| {
+            eprintln!("{:5}|{}|{}", "DEBUG", loc, msg);
+        });
+        self
+    }
+
+    /// Enable info logging on stderr
+    pub fn info(mut self) -> Self {
+        self.builder = self.builder.on_info(|loc, msg| {
+            eprintln!("{:5}|{}|{}", "INFO", loc, msg);
+        });
+        self
+    }
+
+    /// Enable warning logging on stderr
+    pub fn warn(mut self) -> Self {
+        self.builder = self.builder.on_warn(|loc, msg| {
+            eprintln!("{:5}|{}|{}", "WARN", loc, msg);
+        });
+        self
+    }
+
+    /// Enable error logging on stderr
+    pub fn error(mut self) -> Self {
+        self.builder = self.builder.on_error(|loc, msg| {
+            eprintln!("{:5}|{}|{}", "ERROR", loc, msg);
+        });
+        self
+    }
+
+    /// Enable warn and error logging on stderr
+    pub fn warn_error(self) -> Self {
+        self.warn().error()
+    }
+
+    /// Enable info, warn and error logging on stderr
+    pub fn info_warn_error(self) -> Self {
+        self.info().warn().error()
+    }
+
+    /// Enable debug, info, warn and error logging on stderr
+    pub fn all(self) -> Self {
+        self.debug().info().warn().error()
+    }
+
+    /// Get back to the [LoggerFactoryBuilder]
+    pub fn done(self) -> LoggerFactoryBuilder {
+        self.builder
+    }
+
+    /// Build the [LoggerFactory]
+    pub fn finish(self) -> LoggerFactory {
+        self.builder.finish()
+    }
+}
+
+/// A factory for [Logger]s which can be used to create
+/// [Logger]s for downloads.
+///
+/// `LoggerFactory` implements [ReporterFactory].
+/// To ensure logging for all downloads using a [DownloadSession]
+/// with the [LoggerFactory] as a [ReporterFactory] is recommended.
+///
+/// [DownloadSession]: crate::DownloadSession
+#[derive(Clone)]
+pub struct LoggerFactory {
+    inner: Inner,
+}
+
+impl ReporterFactory for LoggerFactory {
+    type ReporterType = Logger;
+
+    fn make(&self, location: &dyn fmt::Display) -> Self::ReporterType {
+        Logger {
+            location: Some(Arc::new(location.to_string())),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Inner {
+    on_debug: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_info: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_warn: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+    on_error: Option<Arc<dyn Fn(&str, fmt::Arguments) + Send + Sync + 'static>>,
+}

--- a/condow_core/src/machinery/downloaders.rs
+++ b/condow_core/src/machinery/downloaders.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
         Arc,
     },
     time::Instant,
@@ -41,8 +41,9 @@ pub(crate) async fn download_concurrently<C: CondowClient, R: Reporter>(
     downloader.download(ranges_stream).await
 }
 
+/// Spawns multiple [InternalDownloader]s to download parts
 struct ConcurrentDownloader<R: Reporter> {
-    downloaders: Vec<Downloader>,
+    downloaders: Vec<SequentialDownloader>,
     counter: usize,
     kill_switch: KillSwitch,
     config: Config,
@@ -63,13 +64,17 @@ impl<R: Reporter> ConcurrentDownloader<R> {
         let counter = Arc::new(AtomicUsize::new(0));
         let downloaders: Vec<_> = (0..n_concurrent)
             .map(|_| {
-                Downloader::new(
+                SequentialDownloader::new(
                     client.clone(),
-                    results_sender.clone(),
-                    kill_switch.clone(),
                     location.clone(),
                     config.buffer_size.into(),
-                    DownloadersWatcher::new(Arc::clone(&counter), reporter.clone(), started_at),
+                    DownloaderContext::new(
+                        results_sender.clone(),
+                        Arc::clone(&counter),
+                        kill_switch.clone(),
+                        reporter.clone(),
+                        started_at,
+                    ),
                 )
             })
             .collect();
@@ -123,84 +128,76 @@ impl<R: Reporter> ConcurrentDownloader<R> {
     }
 }
 
-struct Downloader {
-    sender: Sender<RangeRequest>,
-    kill_switch: KillSwitch,
+/// Downlads parts of download sequentially.
+///
+/// Takes the part ranges ([RangeRequest]s) of of a download and downloads them.
+///
+/// Spawns a task internally to process the parts to be downloaded one by one.
+/// The parts to be downloaded are enqueued in a channel.
+///
+/// Results are pushed into a channel via the [DownloaderContext].
+///
+/// Usually one `SequentialDownloader` is created for each level of
+/// concurrency.  
+struct SequentialDownloader {
+    request_sender: Sender<RangeRequest>,
 }
 
-impl Downloader {
+impl SequentialDownloader {
     pub fn new<C: CondowClient, R: Reporter>(
         client: ClientRetryWrapper<C>,
-        results_sender: UnboundedSender<ChunkStreamItem>,
-        kill_switch: KillSwitch,
         location: C::Location,
         buffer_size: usize,
-        watcher: DownloadersWatcher<R>,
+        mut context: DownloaderContext<R>,
     ) -> Self {
-        let (sender, request_receiver) = mpsc::channel::<RangeRequest>(buffer_size);
+        let (request_sender, request_receiver) = mpsc::channel::<RangeRequest>(buffer_size);
 
-        tokio::spawn({
-            let kill_switch = kill_switch.clone();
-            async move {
-                let mut request_receiver = Box::pin(request_receiver);
-                while let Some(range_request) = request_receiver.next().await {
-                    if kill_switch.is_pushed() {
-                        break;
-                    }
+        tokio::spawn(async move {
+            let mut request_receiver = Box::pin(request_receiver);
+            while let Some(range_request) = request_receiver.next().await {
+                if context.kill_switch.is_pushed() {
+                    // That failed task should have already sent an error...
+                    // ...but we do not want to prove that...
+                    context.send_err(CondowError::new_other(
+                        "another download task already failed",
+                    ));
+                    return;
+                }
 
-                    match client
-                        .download(
-                            location.clone(),
-                            DownloadSpec::Range(range_request.blob_range),
-                            &watcher.reporter,
-                        )
-                        .await
-                    {
-                        Ok((bytes_stream, _total_bytes)) => {
-                            if consume_and_dispatch_bytes(
-                                bytes_stream,
-                                &results_sender,
-                                range_request,
-                                watcher.reporter.clone(),
-                            )
+                match client
+                    .download(
+                        location.clone(),
+                        DownloadSpec::Range(range_request.blob_range),
+                        &context.reporter,
+                    )
+                    .await
+                {
+                    Ok((bytes_stream, _total_bytes)) => {
+                        if consume_and_dispatch_bytes(bytes_stream, &mut context, range_request)
                             .await
                             .is_err()
-                            {
-                                kill_switch.push_the_button();
-                                watcher.mark_failed();
-                                request_receiver.close();
-                                break;
-                            }
+                        {
+                            return;
                         }
-                        Err(err) => {
-                            kill_switch.push_the_button();
-                            watcher.mark_failed();
-                            request_receiver.close();
-                            let _ = results_sender.unbounded_send(Err(err));
-                            break;
-                        }
-                    };
-                }
-                drop(watcher);
+                    }
+                    Err(err) => {
+                        context.send_err(err);
+                        return;
+                    }
+                };
             }
+            context.mark_successful();
+            drop(context);
         });
 
-        Downloader {
-            sender,
-            kill_switch,
-        }
+        SequentialDownloader { request_sender }
     }
 
     pub fn enqueue(&mut self, req: RangeRequest) -> Result<Option<RangeRequest>, ()> {
-        if self.kill_switch.is_pushed() {
-            return Err(());
-        }
-
-        match self.sender.try_send(req) {
+        match self.request_sender.try_send(req) {
             Ok(()) => Ok(None),
             Err(err) => {
                 if err.is_disconnected() {
-                    self.kill_switch.push_the_button();
                     Err(())
                 } else {
                     Ok(Some(err.into_inner()))
@@ -210,34 +207,79 @@ impl Downloader {
     }
 }
 
-struct DownloadersWatcher<R: Reporter> {
+struct DownloaderContext<R: Reporter> {
     started_at: Instant,
     counter: Arc<AtomicUsize>,
-    is_failed: Arc<AtomicBool>,
+    kill_switch: KillSwitch,
     reporter: R,
+    results_sender: UnboundedSender<ChunkStreamItem>,
+    completed: bool,
 }
 
-impl<R: Reporter> DownloadersWatcher<R> {
-    pub fn new(counter: Arc<AtomicUsize>, reporter: R, started_at: Instant) -> Self {
+impl<R: Reporter> DownloaderContext<R> {
+    pub fn new(
+        results_sender: UnboundedSender<ChunkStreamItem>,
+        counter: Arc<AtomicUsize>,
+        kill_switch: KillSwitch,
+        reporter: R,
+        started_at: Instant,
+    ) -> Self {
         counter.fetch_add(1, Ordering::SeqCst);
         Self {
             counter,
             reporter,
-            is_failed: Arc::new(AtomicBool::new(false)),
+            kill_switch,
             started_at,
+            results_sender,
+            completed: false,
         }
     }
 
-    pub fn mark_failed(&self) {
-        self.is_failed.store(true, Ordering::SeqCst);
+    pub fn send_chunk(&self, chunk: Chunk) -> Result<(), ()> {
+        if self.results_sender.unbounded_send(Ok(chunk)).is_ok() {
+            return Ok(());
+        }
+
+        self.kill_switch.push_the_button();
+
+        return Err(());
+    }
+
+    /// Send an error and mark as completed
+    pub fn send_err(&mut self, err: CondowError) {
+        let _ = self.results_sender.unbounded_send(Err(err));
+        self.completed = true;
+        self.kill_switch.push_the_button();
+    }
+
+    /// Mark the download as complete if successful
+    ///
+    /// This must be called upon succesful termination of an [InternalDownloader].
+    ///
+    /// If the download was not marked complete, an error will be sent when dropped
+    /// (a panic is assumed).
+    pub fn mark_successful(&mut self) {
+        self.completed = true;
     }
 }
 
-impl<R: Reporter> Drop for DownloadersWatcher<R> {
+impl<R: Reporter> Drop for DownloaderContext<R> {
     fn drop(&mut self) {
+        if !self.completed {
+            self.kill_switch.push_the_button();
+
+            let err = if std::thread::panicking() {
+                self.reporter.panic_detected("panic detected in downloader");
+                CondowError::new_other("download ended unexpectedly due to a panic")
+            } else {
+                CondowError::new_other("download ended unexpectetly")
+            };
+            let _ = self.results_sender.unbounded_send(Err(err));
+        }
+
         self.counter.fetch_sub(1, Ordering::SeqCst);
         if self.counter.load(Ordering::SeqCst) == 0 {
-            if self.is_failed.load(Ordering::SeqCst) {
+            if self.kill_switch.is_pushed() {
                 self.reporter
                     .download_failed(Some(self.started_at.elapsed()))
             } else {
@@ -249,9 +291,8 @@ impl<R: Reporter> Drop for DownloadersWatcher<R> {
 
 async fn consume_and_dispatch_bytes<R: Reporter>(
     mut bytes_stream: BytesStream,
-    results_sender: &UnboundedSender<ChunkStreamItem>,
+    context: &mut DownloaderContext<R>,
     range_request: RangeRequest,
-    reporter: R,
 ) -> Result<(), ()> {
     let mut chunk_index = 0;
     let mut offset_in_range = 0;
@@ -260,7 +301,9 @@ async fn consume_and_dispatch_bytes<R: Reporter>(
     let part_start = Instant::now();
     let mut chunk_start = Instant::now();
 
-    reporter.part_started(range_request.part_index, range_request.blob_range);
+    context
+        .reporter
+        .part_started(range_request.part_index, range_request.blob_range);
 
     while let Some(bytes_res) = bytes_stream.next().await {
         match bytes_res {
@@ -271,41 +314,44 @@ async fn consume_and_dispatch_bytes<R: Reporter>(
                 bytes_received += bytes.len() as u64;
 
                 if bytes_received > bytes_expected {
-                    let msg = Err(CondowError::new_other(format!(
+                    let err = CondowError::new_other(format!(
                         "received more bytes than expected for part {} ({}..={}). expected {}, received {}",
                         range_request.part_index,
                         range_request.blob_range.start(),
                         range_request.blob_range.end_incl(),
                         range_request.blob_range.len(),
                         bytes_received
-                    )));
-                    let _ = results_sender.unbounded_send(msg);
+                    ));
+                    context.send_err(err);
                     return Err(());
                 }
 
-                reporter.chunk_completed(range_request.part_index, chunk_index, n_bytes, t_chunk);
+                context.reporter.chunk_completed(
+                    range_request.part_index,
+                    chunk_index,
+                    n_bytes,
+                    t_chunk,
+                );
 
-                results_sender
-                    .unbounded_send(Ok(Chunk {
-                        part_index: range_request.part_index,
-                        chunk_index,
-                        blob_offset: range_request.blob_range.start() + offset_in_range,
-                        range_offset: range_request.range_offset + offset_in_range,
-                        bytes,
-                        bytes_left: bytes_expected - bytes_received,
-                    }))
-                    .map_err(|_| ())?;
+                context.send_chunk(Chunk {
+                    part_index: range_request.part_index,
+                    chunk_index,
+                    blob_offset: range_request.blob_range.start() + offset_in_range,
+                    range_offset: range_request.range_offset + offset_in_range,
+                    bytes,
+                    bytes_left: bytes_expected - bytes_received,
+                })?;
                 chunk_index += 1;
                 offset_in_range += n_bytes as u64;
             }
             Err(IoError(msg)) => {
-                let _ = results_sender.unbounded_send(Err(CondowError::new_io(msg)));
+                context.send_err(CondowError::new_io(msg));
                 return Err(());
             }
         }
     }
 
-    reporter.part_completed(
+    context.reporter.part_completed(
         range_request.part_index,
         chunk_index,
         bytes_received,
@@ -313,23 +359,22 @@ async fn consume_and_dispatch_bytes<R: Reporter>(
     );
 
     if bytes_received != bytes_expected {
-        let msg = Err(CondowError::new_other(format!(
+        let err = CondowError::new_other(format!(
             "received wrong number of bytes for part {} ({}..={}). expected {}, received {}",
             range_request.part_index,
             range_request.blob_range.start(),
             range_request.blob_range.end_incl(),
             range_request.blob_range.len(),
             bytes_received
-        )));
-        let _ = results_sender.unbounded_send(msg);
+        ));
+        let _ = context.send_err(err);
         Err(())
     } else {
         Ok(())
     }
 }
-
 #[cfg(test)]
-mod tests {
+mod downloader_tests {
     use std::{
         sync::{atomic::AtomicUsize, Arc},
         time::Instant,
@@ -338,10 +383,13 @@ mod tests {
     use futures::StreamExt;
 
     use crate::{
-        condow_client::NoLocation,
+        condow_client::{
+            failing_client_simulator::FailingClientSimulatorBuilder, CondowClient, NoLocation,
+        },
         config::Config,
+        errors::{CondowError, CondowErrorKind},
         machinery::{
-            downloaders::{Downloader, DownloadersWatcher},
+            downloaders::{DownloaderContext, SequentialDownloader},
             range_stream::RangeStream,
             KillSwitch,
         },
@@ -360,11 +408,28 @@ mod tests {
             InclusiveRange(0, 9),
             InclusiveRange(0, 10),
         ] {
-            check(range, client.clone(), 10).await
+            check(range, client.clone(), 10).await.unwrap()
         }
     }
 
-    async fn check(range: InclusiveRange, client: TestCondowClient, part_size_bytes: u64) {
+    #[tokio::test]
+    async fn failing_request() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+        let client = FailingClientSimulatorBuilder::default()
+            .blob(blob)
+            .chunk_size(100)
+            .responses()
+            .failure(CondowErrorKind::Other)
+            .finish();
+
+        assert!(check(InclusiveRange(0, 99), client, 100).await.is_err());
+    }
+
+    async fn check<C: CondowClient<Location = NoLocation>>(
+        range: InclusiveRange,
+        client: C,
+        part_size_bytes: u64,
+    ) -> Result<(), CondowError> {
         let config = Config::default()
             .buffer_size(10)
             .buffers_full_delay_ms(0)
@@ -378,13 +443,17 @@ mod tests {
 
         let (result_stream, results_sender) = ChunkStream::new(bytes_hint);
 
-        let mut downloader = Downloader::new(
+        let mut downloader = SequentialDownloader::new(
             client.into(),
-            results_sender,
-            KillSwitch::new(),
             NoLocation,
             config.buffer_size.into(),
-            DownloadersWatcher::new(Arc::new(AtomicUsize::new(0)), NoReporting, Instant::now()),
+            DownloaderContext::new(
+                results_sender,
+                Arc::new(AtomicUsize::new(0)),
+                KillSwitch::new(),
+                NoReporting,
+                Instant::now(),
+            ),
         );
 
         while let Some(next) = ranges_stream.next().await {
@@ -394,7 +463,7 @@ mod tests {
         drop(downloader); // Ends the stream
 
         let result = result_stream.collect::<Vec<_>>().await;
-        let result = result.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
+        let result = result.into_iter().collect::<Result<Vec<_>, _>>()?;
 
         let total_bytes: u64 = result.iter().map(|c| c.bytes.len() as u64).sum();
         assert_eq!(total_bytes, range.len(), "total_bytes");
@@ -423,5 +492,7 @@ mod tests {
             next_range_offset += bytes.len() as u64;
             next_blob_offset += bytes.len() as u64;
         });
+
+        Ok(())
     }
 }

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -36,8 +36,6 @@ pub async fn download_range<C: CondowClient, DR: Into<DownloadRange>, R: Reporte
     get_size_mode: GetSizeMode,
     reporter: R,
 ) -> Result<StreamWithReport<ChunkStream, R>, CondowError> {
-    reporter.location(&location);
-
     let range: DownloadRange = range.into();
     range.validate()?;
     let range = if let Some(range) = range.sanitized() {
@@ -125,107 +123,6 @@ async fn download_chunks<C: CondowClient, R: Reporter>(
     Ok(chunk_stream)
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::{
-        condow_client::NoLocation, config::Config, machinery::download_chunks,
-        reporter::NoReporting, streams::BytesHint, test_utils::*, InclusiveRange,
-    };
-
-    #[tokio::test]
-    async fn from_0_to_inclusive_range_smaller_than_part_size() {
-        let buffer_size = 10;
-        let client = TestCondowClient::new().max_chunk_size(3);
-        let data = client.data();
-
-        let config = Config::default()
-            .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
-            .part_size_bytes(10)
-            .max_concurrency(1);
-
-        let range = InclusiveRange(0, 8);
-        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
-
-        let result_stream = download_chunks(
-            client.into(),
-            NoLocation,
-            range,
-            bytes_hint,
-            config,
-            NoReporting,
-        )
-        .await
-        .unwrap();
-
-        let result = result_stream.into_vec().await.unwrap();
-
-        assert_eq!(&result, &data[range.to_std_range_usize()]);
-    }
-
-    #[tokio::test]
-    async fn from_0_to_inclusive_range_equal_size_than_part_size() {
-        let buffer_size = 10;
-        let client = TestCondowClient::new().max_chunk_size(3);
-        let data = client.data();
-
-        let config = Config::default()
-            .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
-            .part_size_bytes(10)
-            .max_concurrency(1);
-
-        let range = InclusiveRange(0, 9);
-        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
-
-        let result_stream = download_chunks(
-            client.into(),
-            NoLocation,
-            range,
-            bytes_hint,
-            config,
-            NoReporting,
-        )
-        .await
-        .unwrap();
-
-        let result = result_stream.into_vec().await.unwrap();
-
-        assert_eq!(&result, &data[range.to_std_range_usize()]);
-    }
-
-    #[tokio::test]
-    async fn from_0_to_inclusive_range_larger_than_part_size() {
-        let buffer_size = 10;
-        let client = TestCondowClient::new().max_chunk_size(3);
-        let data = client.data();
-
-        let config = Config::default()
-            .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
-            .part_size_bytes(10)
-            .max_concurrency(1);
-
-        let range = InclusiveRange(0, 10);
-        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
-
-        let result_stream = download_chunks(
-            client.into(),
-            NoLocation,
-            range,
-            bytes_hint,
-            config,
-            NoReporting,
-        )
-        .await
-        .unwrap();
-
-        let result = result_stream.into_vec().await.unwrap();
-
-        assert_eq!(&result, &data[range.to_std_range_usize()]);
-    }
-}
-
 #[derive(Clone)]
 struct KillSwitch {
     is_pushed: Arc<AtomicBool>,
@@ -246,3 +143,6 @@ impl KillSwitch {
         self.is_pushed.store(true, Ordering::Relaxed)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/condow_core/src/machinery/range_stream.rs
+++ b/condow_core/src/machinery/range_stream.rs
@@ -2,10 +2,14 @@ use futures::Stream;
 
 use crate::InclusiveRange;
 
+/// A request to downlaod a range.
+///
+/// This is usually a part of a download.
 #[derive(Debug)]
 pub struct RangeRequest {
     /// Index of the part
     pub part_index: u64,
+    /// The range to be downloaded from the BLOB.
     pub blob_range: InclusiveRange,
     /// Offset of the part within the downloaded range
     pub range_offset: u64,

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -1,0 +1,359 @@
+mod download {
+    use crate::{
+        condow_client::{failing_client_simulator::FailingClientSimulatorBuilder, NoLocation},
+        config::Config,
+        errors::CondowErrorKind,
+        machinery::download,
+        reporter::NoReporting,
+    };
+
+    #[tokio::test]
+    async fn download_ok() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(2)
+            .disable_retries();
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        let result_bytes = stream.into_vec().await.unwrap();
+
+        assert_eq!(result_bytes, blob);
+    }
+
+    #[tokio::test]
+    async fn download_request_failure() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(2)
+            .disable_retries();
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .failure(CondowErrorKind::Other)
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        assert_eq!(
+            stream.into_vec().await.unwrap_err().kind(),
+            CondowErrorKind::Other
+        );
+    }
+
+    #[tokio::test]
+    async fn download_stream_error() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(2)
+            .disable_retries();
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .success_with_stream_failure(5)
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        assert_eq!(
+            stream.into_vec().await.unwrap_err().kind(),
+            CondowErrorKind::Io
+        );
+    }
+
+    #[tokio::test]
+    async fn download_panic_no_retries() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(2)
+            .disable_retries();
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .panic("BAMM!")
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        let err = stream.into_vec().await.unwrap_err();
+
+        assert_eq!(err.kind(), CondowErrorKind::Other);
+
+        assert_eq!(err.msg(), "download ended unexpectedly due to a panic");
+    }
+
+    #[tokio::test]
+    async fn download_panic_in_retry_after_stream_failure() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(1)
+            .configure_retries(|rc| rc.max_attempts(1).initial_delay_ms(0));
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .success_with_stream_failure(5)
+            .panic("BAMM!")
+            .never()
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        let err = stream.into_vec().await.unwrap_err();
+
+        assert_eq!(err.kind(), CondowErrorKind::Io);
+
+        assert_eq!(err.msg(), "panicked while retrying");
+    }
+
+    #[tokio::test]
+    async fn download_panic_while_streaming() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(2)
+            .disable_retries();
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .success_with_stream_panic(5)
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        let err = stream.into_vec().await.unwrap_err();
+
+        assert_eq!(err.kind(), CondowErrorKind::Other);
+
+        assert_eq!(err.msg(), "download ended unexpectedly due to a panic");
+    }
+
+    #[tokio::test]
+    async fn download_panic_in_retry_while_streaming() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+
+        let config = Config::default()
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(1)
+            .configure_retries(|rc| rc.max_attempts(1).initial_delay_ms(0));
+
+        let condow = FailingClientSimulatorBuilder::default()
+            .blob(blob.clone())
+            .responses()
+            .success_with_stream_failure(5)
+            .success_with_stream_panic(5)
+            .never()
+            .finish()
+            .condow(config)
+            .unwrap();
+
+        let result = download(
+            &condow,
+            NoLocation,
+            0..100,
+            crate::GetSizeMode::Required,
+            NoReporting,
+        )
+        .await;
+
+        let (stream, _report) = result.unwrap().into_parts();
+
+        let err = stream.into_vec().await.unwrap_err();
+
+        assert_eq!(err.kind(), CondowErrorKind::Io);
+
+        assert_eq!(err.msg(), "panicked while retrying");
+    }
+}
+
+mod download_chunks {
+    use crate::{
+        condow_client::NoLocation, config::Config, machinery::download_chunks,
+        reporter::NoReporting, streams::BytesHint, test_utils::*, InclusiveRange,
+    };
+
+    #[tokio::test]
+    async fn from_0_to_inclusive_range_smaller_than_part_size() {
+        let buffer_size = 10;
+        let client = TestCondowClient::new().max_chunk_size(3);
+        let data = client.data();
+
+        let config = Config::default()
+            .buffer_size(buffer_size)
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(1);
+
+        let range = InclusiveRange(0, 8);
+        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+
+        let result_stream = download_chunks(
+            client.into(),
+            NoLocation,
+            range,
+            bytes_hint,
+            config,
+            NoReporting,
+        )
+        .await
+        .unwrap();
+
+        let result = result_stream.into_vec().await.unwrap();
+
+        assert_eq!(&result, &data[range.to_std_range_usize()]);
+    }
+
+    #[tokio::test]
+    async fn from_0_to_inclusive_range_equal_size_than_part_size() {
+        let buffer_size = 10;
+        let client = TestCondowClient::new().max_chunk_size(3);
+        let data = client.data();
+
+        let config = Config::default()
+            .buffer_size(buffer_size)
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(1);
+
+        let range = InclusiveRange(0, 9);
+        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+
+        let result_stream = download_chunks(
+            client.into(),
+            NoLocation,
+            range,
+            bytes_hint,
+            config,
+            NoReporting,
+        )
+        .await
+        .unwrap();
+
+        let result = result_stream.into_vec().await.unwrap();
+
+        assert_eq!(&result, &data[range.to_std_range_usize()]);
+    }
+
+    #[tokio::test]
+    async fn from_0_to_inclusive_range_larger_than_part_size() {
+        let buffer_size = 10;
+        let client = TestCondowClient::new().max_chunk_size(3);
+        let data = client.data();
+
+        let config = Config::default()
+            .buffer_size(buffer_size)
+            .buffers_full_delay_ms(0)
+            .part_size_bytes(10)
+            .max_concurrency(1);
+
+        let range = InclusiveRange(0, 10);
+        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+
+        let result_stream = download_chunks(
+            client.into(),
+            NoLocation,
+            range,
+            bytes_hint,
+            config,
+            NoReporting,
+        )
+        .await
+        .unwrap();
+
+        let result = result_stream.into_vec().await.unwrap();
+
+        assert_eq!(&result, &data[range.to_std_range_usize()]);
+    }
+}

--- a/condow_core/src/streams/chunk_stream.rs
+++ b/condow_core/src/streams/chunk_stream.rs
@@ -120,12 +120,14 @@ impl ChunkStream {
     /// not know, whether we can fill the buffer in a contiguous way.
     pub async fn write_buffer(mut self, buffer: &mut [u8]) -> Result<usize, CondowError> {
         if !self.is_fresh {
+            self.receiver.close();
             return Err(CondowError::new_other(
                 "stream already iterated".to_string(),
             ));
         }
 
         if (buffer.len() as u64) < self.bytes_hint.lower_bound() {
+            self.receiver.close();
             return Err(CondowError::new_other(format!(
                 "buffer to small ({}). at least {} bytes required",
                 buffer.len(),
@@ -146,6 +148,7 @@ impl ChunkStream {
             };
 
             if range_offset > usize::MAX as u64 {
+                self.receiver.close();
                 return Err(CondowError::new_other(
                     "usize overflow while casting from u64",
                 ));
@@ -155,6 +158,7 @@ impl ChunkStream {
 
             let end_excl = range_offset + bytes.len();
             if end_excl > buffer.len() {
+                self.receiver.close();
                 return Err(CondowError::new_other(format!(
                     "write attempt beyond buffer end (buffer len = {}). \
                     attempted to write at index {}",
@@ -177,9 +181,10 @@ impl ChunkStream {
     ///
     /// Since the parts and therefore the chunks are not ordered we can
     /// not know, whether we can fill the `Vec` in a contiguous way.
-    pub async fn into_vec(self) -> Result<Vec<u8>, CondowError> {
+    pub async fn into_vec(mut self) -> Result<Vec<u8>, CondowError> {
         if let Some(total_bytes) = self.bytes_hint.exact() {
             if total_bytes > usize::MAX as u64 {
+                self.receiver.close();
                 return Err(CondowError::new_other(
                     "usize overflow while casting from u64",
                 ));
@@ -205,6 +210,7 @@ async fn stream_into_vec_with_unknown_size(
     mut stream: ChunkStream,
 ) -> Result<Vec<u8>, CondowError> {
     if !stream.is_fresh {
+        stream.receiver.close();
         return Err(CondowError::new_other(
             "stream already iterated".to_string(),
         ));
@@ -212,6 +218,7 @@ async fn stream_into_vec_with_unknown_size(
 
     let lower_bound = stream.bytes_hint.lower_bound();
     if lower_bound > usize::MAX as u64 {
+        stream.receiver.close();
         return Err(CondowError::new_other(
             "usize overflow while casting from u64",
         ));
@@ -230,6 +237,7 @@ async fn stream_into_vec_with_unknown_size(
         };
 
         if range_offset > usize::MAX as u64 {
+            stream.receiver.close();
             return Err(CondowError::new_other(
                 "usize overflow while casting from u64",
             ));
@@ -291,21 +299,57 @@ mod tests {
     use futures::StreamExt;
 
     use crate::{
+        errors::CondowError,
         streams::{BytesHint, Chunk, ChunkStream},
-        test_utils::create_chunk_stream,
+        test_utils::{create_chunk_stream, create_chunk_stream_with_err},
     };
 
     #[tokio::test]
-    async fn check() {
+    async fn check_ok() {
         for n_parts in 1..20 {
             for n_chunks in 1..20 {
                 let (stream, expected) = create_chunk_stream(n_parts, n_chunks, true, Some(10));
-                check_stream(stream, &expected).await
+                check_stream(stream, &expected).await.unwrap()
             }
         }
     }
 
-    async fn check_stream(mut result_stream: ChunkStream, data: &[u8]) {
+    #[tokio::test]
+    async fn check_err_begin() {
+        for n_parts in 1..20 {
+            for n_chunks in 1..20 {
+                let (stream, expected) =
+                    create_chunk_stream_with_err(n_parts, n_chunks, true, Some(10), 0);
+                assert!(check_stream(stream, &expected).await.is_err())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn check_err_end() {
+        for n_parts in 1..20u64 {
+            for n_chunks in 1..20usize {
+                let err_at_chunk = n_parts as usize * n_chunks - 1;
+                let (stream, expected) =
+                    create_chunk_stream_with_err(n_parts, n_chunks, true, Some(10), err_at_chunk);
+                assert!(check_stream(stream, &expected).await.is_err())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn check_err_after_end() {
+        for n_parts in 1..20u64 {
+            for n_chunks in 1..20usize {
+                let err_at_chunk = n_parts as usize * n_chunks;
+                let (stream, expected) =
+                    create_chunk_stream_with_err(n_parts, n_chunks, true, Some(10), err_at_chunk);
+                assert!(check_stream(stream, &expected).await.is_err())
+            }
+        }
+    }
+
+    async fn check_stream(mut result_stream: ChunkStream, data: &[u8]) -> Result<(), CondowError> {
         let mut bytes_left = data.len();
         let mut first_blob_offset = 0;
         let mut got_first = false;
@@ -321,7 +365,7 @@ mod tests {
                 bytes,
                 ..
             } = match next {
-                Err(err) => panic!("{}", err),
+                Err(err) => return Err(err),
                 Ok(next) => next,
             };
 
@@ -352,5 +396,7 @@ mod tests {
                 "blob_offset"
             );
         }
+
+        Ok(())
     }
 }

--- a/condow_core/src/streams/mod.rs
+++ b/condow_core/src/streams/mod.rs
@@ -1,4 +1,6 @@
-//! Streams used by Condow
+//! Stream implememtations used by Condow
+use std::fmt;
+
 use crate::errors::IoError;
 use bytes::Bytes;
 use futures::stream::BoxStream;
@@ -9,7 +11,7 @@ mod part_stream;
 pub use chunk_stream::*;
 pub use part_stream::*;
 
-/// A stream of [Bytes]
+/// A stream of [Bytes] (chunks) where there can be an error for each chunk of bytes
 pub type BytesStream = BoxStream<'static, Result<Bytes, IoError>>;
 
 /// Returns the bounds on the remaining bytes of the stream.
@@ -135,5 +137,16 @@ impl BytesHint {
     /// Turns this into the inner tuple
     pub fn into_inner(self) -> (u64, Option<u64>) {
         (self.lower_bound(), self.upper_bound())
+    }
+}
+
+impl fmt::Display for BytesHint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (lower, upper) = self.into_inner();
+
+        match upper {
+            Some(upper) => write!(f, "[{}..{}]", lower, upper),
+            None => write!(f, "[{}..?[", lower),
+        }
     }
 }


### PR DESCRIPTION
Changelog:

## [0.12.1] - unreleased

### FIXED

- return a stream error when panicking while downloading
- return a stream error when panicking while retrying

### ADDED

- add a function to `Reporter` trait to track panics
- documentation
- `FailingClientSimulator` can panic while streaming
- Display for `BytesHint`
- Logging via the `Reporter` trait

### CHANGED

- `FailingClientSimulator` does stream errors based on the requested range

### REMOVED

- location method from `Reporter` trait. Use constructor to set a location.



closes #31