### PR TITLE
Use a concrete type for all download locations

### DIFF
--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -17,8 +17,10 @@ pin-project-lite = "0.2"
 bytes = "1"
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time"] }
+tracing = "0.1.32"
 thiserror = "1.0"
 anyhow = "1.0"
+url = "2.2.2"
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/condow_core/src/condow_tests.rs
+++ b/condow_core/src/condow_tests.rs
@@ -34,7 +34,10 @@ mod blob {
                     let downloader =
                         condow.downloader_with_reporting(SimpleReporterFactory::default());
 
-                    let result_stream = downloader.download_rep(NoLocation, ..).await.unwrap();
+                    let result_stream = downloader
+                        .download_rep(url::Url::parse("noscheme://").expect("a valid URL"), ..)
+                        .await
+                        .unwrap();
 
                     let result = result_stream.into_stream().into_vec().await.unwrap();
 
@@ -70,7 +73,10 @@ mod blob {
                     let downloader =
                         condow.downloader_with_reporting(SimpleReporterFactory::default());
 
-                    let result_stream = downloader.download_rep(NoLocation, ..).await.unwrap();
+                    let result_stream = downloader
+                        .download_rep(url::Url::parse("noscheme://").expect("a valid URL"), ..)
+                        .await
+                        .unwrap();
 
                     let report = result_stream.reporter.report();
                     assert!(report.download_time > Duration::ZERO);
@@ -117,7 +123,7 @@ mod range {
 
                             let result_stream = machinery::download(
                                 &condow,
-                                NoLocation,
+                                url::Url::parse("noscheme://").expect("a valid URL"),
                                 range.clone(),
                                 crate::GetSizeMode::Always,
                                 SimpleReporter::default(),
@@ -163,7 +169,7 @@ mod range {
 
                             let result_stream = machinery::download(
                                 &condow,
-                                NoLocation,
+                                url::Url::parse("noscheme://").expect("a valid URL"),
                                 range.clone(),
                                 crate::GetSizeMode::Required,
                                 SimpleReporter::default(),
@@ -219,7 +225,7 @@ mod range {
 
                             let result_stream = machinery::download(
                                 &condow,
-                                NoLocation,
+                                url::Url::parse("noscheme://").expect("a valid URL"),
                                 range.clone(),
                                 crate::GetSizeMode::Default,
                                 SimpleReporter::default(),
@@ -265,7 +271,7 @@ mod range {
 
                             let result_stream = machinery::download(
                                 &condow,
-                                NoLocation,
+                                url::Url::parse("noscheme://").expect("a valid URL"),
                                 range.clone(),
                                 crate::GetSizeMode::Default,
                                 SimpleReporter::default(),
@@ -321,7 +327,7 @@ mod range {
 
                                     let result_stream = machinery::download(
                                         &condow,
-                                        NoLocation,
+                                        url::Url::parse("noscheme://").expect("a valid URL"),
                                         range,
                                         crate::GetSizeMode::Default,
                                         SimpleReporter::default(),
@@ -368,7 +374,7 @@ mod range {
 
                                     let result_stream = machinery::download(
                                         &condow,
-                                        NoLocation,
+                                        url::Url::parse("noscheme://").expect("a valid URL"),
                                         range,
                                         crate::GetSizeMode::Default,
                                         SimpleReporter::default(),
@@ -427,7 +433,7 @@ mod range {
 
                                         let result_stream = machinery::download(
                                             &condow,
-                                            NoLocation,
+                                            url::Url::parse("noscheme://").expect("a valid URL"),
                                             range,
                                             crate::GetSizeMode::Default,
                                             SimpleReporter::default(),
@@ -481,7 +487,7 @@ mod range {
 
                                         let result_stream = machinery::download(
                                             &condow,
-                                            NoLocation,
+                                            url::Url::parse("noscheme://").expect("a valid URL"),
                                             range,
                                             crate::GetSizeMode::Default,
                                             SimpleReporter::default(),

--- a/condow_core/src/machinery/download/concurrent.rs
+++ b/condow_core/src/machinery/download/concurrent.rs
@@ -34,7 +34,7 @@ impl<R: Reporter> ConcurrentDownloader<R> {
         results_sender: UnboundedSender<ChunkStreamItem>,
         client: ClientRetryWrapper<C>,
         config: Config,
-        location: C::Location,
+        location: url::Url,
         reporter: R,
     ) -> Self {
         let started_at = Instant::now();

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -28,7 +28,7 @@ pub(crate) async fn download_concurrently<C: CondowClient, R: Reporter>(
     results_sender: UnboundedSender<ChunkStreamItem>,
     client: ClientRetryWrapper<C>,
     config: Config,
-    location: C::Location,
+    location: url::Url,
     reporter: R,
 ) -> Result<(), ()> {
     let mut downloader = ConcurrentDownloader::new(

--- a/condow_core/src/machinery/download/sequential.rs
+++ b/condow_core/src/machinery/download/sequential.rs
@@ -40,7 +40,7 @@ pub(crate) struct SequentialDownloader {
 impl SequentialDownloader {
     pub fn new<C: CondowClient, R: Reporter>(
         client: ClientRetryWrapper<C>,
-        location: C::Location,
+        location: url::Url,
         buffer_size: usize,
         mut context: DownloaderContext<R>,
     ) -> Self {
@@ -350,7 +350,7 @@ mod tests {
         assert!(check(InclusiveRange(0, 99), client, 100).await.is_err());
     }
 
-    async fn check<C: CondowClient<Location = NoLocation>>(
+    async fn check<C: CondowClient>(
         range: InclusiveRange,
         client: C,
         part_size_bytes: u64,
@@ -370,7 +370,7 @@ mod tests {
 
         let mut downloader = SequentialDownloader::new(
             client.into(),
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid url"),
             config.buffer_size.into(),
             DownloaderContext::new(
                 results_sender,

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -14,7 +14,7 @@ mod range_stream;
 
 pub async fn download<C: CondowClient, DR: Into<DownloadRange>, R: Reporter>(
     condow: &Condow<C>,
-    location: C::Location,
+    location: url::Url,
     range: DR,
     get_size_mode: GetSizeMode,
     reporter: R,
@@ -29,7 +29,7 @@ pub async fn download<C: CondowClient, DR: Into<DownloadRange>, R: Reporter>(
 
 pub async fn download_range<C: CondowClient, DR: Into<DownloadRange>, R: Reporter>(
     condow: &Condow<C>,
-    location: C::Location,
+    location: url::Url,
     range: DR,
     get_size_mode: GetSizeMode,
     reporter: R,
@@ -82,7 +82,7 @@ pub async fn download_range<C: CondowClient, DR: Into<DownloadRange>, R: Reporte
 
 async fn download_chunks<C: CondowClient, R: Reporter>(
     client: ClientRetryWrapper<C>,
-    location: C::Location,
+    location: url::Url,
     range: InclusiveRange,
     bytes_hint: BytesHint,
     config: Config,

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -25,7 +25,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -59,7 +59,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -94,7 +94,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -129,7 +129,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -167,7 +167,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -203,7 +203,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -241,7 +241,7 @@ mod download {
 
         let result = download(
             &condow,
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             0..100,
             crate::GetSizeMode::Required,
             NoReporting,
@@ -281,7 +281,7 @@ mod download_chunks {
 
         let result_stream = download_chunks(
             client.into(),
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             range,
             bytes_hint,
             config,
@@ -312,7 +312,7 @@ mod download_chunks {
 
         let result_stream = download_chunks(
             client.into(),
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             range,
             bytes_hint,
             config,
@@ -343,7 +343,7 @@ mod download_chunks {
 
         let result_stream = download_chunks(
             client.into(),
-            NoLocation,
+            url::Url::parse("noscheme://").expect("a valid URL"),
             range,
             bytes_hint,
             config,

--- a/condow_core/src/retry/mod.rs
+++ b/condow_core/src/retry/mod.rs
@@ -349,7 +349,7 @@ where
 
     pub async fn get_size<R: Reporter>(
         &self,
-        location: C::Location,
+        location: url::Url,
         reporter: &R,
     ) -> Result<u64, CondowError>
     where
@@ -365,7 +365,7 @@ where
 
     pub async fn download<R: Reporter>(
         &self,
-        location: C::Location,
+        location: url::Url,
         spec: DownloadSpec,
         reporter: &R,
     ) -> Result<(BytesStream, BytesHint), CondowError> {
@@ -391,7 +391,7 @@ where
 /// Retries on the `get_size` request according to the [RetryConfig]
 async fn retry_get_size<C, R>(
     client: &C,
-    location: C::Location,
+    location: url::Url,
     config: &RetryConfig,
     reporter: &R,
 ) -> Result<u64, CondowError>
@@ -429,7 +429,7 @@ where
 /// a new stream starting where the broken one ended will be made.
 async fn retry_download<C, R>(
     client: &C,
-    location: C::Location,
+    location: url::Url,
     spec: DownloadSpec,
     config: &RetryConfig,
     reporter: &R,
@@ -513,7 +513,7 @@ where
 /// requesting new stream for the remainder of `original_range`
 async fn loop_retry_complete_stream<C, R>(
     mut stream: BytesStream,
-    location: C::Location,
+    location: url::Url,
     original_range: InclusiveRange,
     client: C,
     next_elem_tx: mpsc::UnboundedSender<Result<Bytes, IoError>>,
@@ -620,7 +620,7 @@ async fn try_consume_stream<St: Stream<Item = Result<Bytes, IoError>>>(
 /// Retries to get a new stream for the given download spec.
 async fn retry_download_get_stream<C, R>(
     client: &C,
-    location: C::Location,
+    location: url::Url,
     spec: DownloadSpec,
     config: &RetryConfig,
     reporter: &R,

--- a/condow_fs/Cargo.toml
+++ b/condow_fs/Cargo.toml
@@ -19,4 +19,4 @@ futures = "0.3"
 anyhow = "1.0"
 tokio = { version = "1", features = ["fs", "io-util"] }
 bytes = "1"
-
+url = "2.2.2"

--- a/condow_fs/tests/test.rs
+++ b/condow_fs/tests/test.rs
@@ -4,11 +4,11 @@ fn create_condow_condow() -> Condow<FsClient> {
     FsClient::condow(Default::default()).unwrap()
 }
 
-fn get_test_file_path() -> String {
-    format!(
-        "{}/tests/test_data",
-        std::env::current_dir().unwrap().display()
-    )
+fn get_test_file_path() -> url::Url {
+    let mut path = std::env::current_dir().unwrap();
+    path.push("tests");
+    path.push("test_data");
+    url::Url::from_file_path(path).expect("path should be absolute")
 }
 
 #[tokio::test]

--- a/condow_rusoto/Cargo.toml
+++ b/condow_rusoto/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 anyhow = "1.0"
 rusoto_core = { version = "0.47", default_features = false }
 rusoto_s3 = { version = "0.47", default_features = false }
+url = "2.2.2"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
This is a draft, and there are things I want to consider/do
* What about if the the client wants to operate on a set of URLs (ie the downloader is not bandwidth constrained but the uploader is, so they horizontally scale the uploader)
  * maybe we need to introduce a trait for locations (but just don't make it an associated type otherwise I can't tear out the loggers)
* What do pre-signed requests look like? (ie can the be in the `s3` scheme)

* need tests for condow_s3
* need to validate this still works against S3 (my local example seems to be breaking)