### PR TITLE
#45 improve performance for small downloads

### DIFF
--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 - 2022-04-27
+
+### CHANGED
+
+- `PartStream` has been replaced by an `OrderedChunkStream` to achieve a lower first byte to client latency
+
 ## 0.13.0 - 2022-04-27
 
 ### CHANGED

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_core"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -45,7 +45,7 @@ use errors::CondowError;
 use machinery::ProbeInternal;
 use probe::{Probe, ProbeFactory};
 use reader::{CondowAdapter, RandomAccessReader};
-use streams::{ChunkStream, PartStream};
+use streams::{ChunkStream, OrderedChunkStream};
 
 #[macro_use]
 pub(crate) mod helpers;

--- a/condow_core/src/reader/random_access_reader.rs
+++ b/condow_core/src/reader/random_access_reader.rs
@@ -16,7 +16,7 @@ use crate::{
     condow_client::CondowClient,
     config::Mebi,
     errors::CondowError,
-    streams::{ChunkStream, PartStream},
+    streams::{ChunkStream, OrderedChunkStream},
     Condow, DownloadRange,
 };
 
@@ -82,7 +82,7 @@ pub trait ReaderAdapter: Send + Sync + 'static {
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<PartStream<ChunkStream>, CondowError>>;
+    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>>;
 }
 
 pub(crate) struct CondowAdapter<C: CondowClient> {
@@ -107,7 +107,7 @@ where
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<PartStream<ChunkStream>, CondowError>> {
+    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>> {
         self.condow
             .blob()
             .range(range)

--- a/condow_core/src/reader/random_access_reader.rs
+++ b/condow_core/src/reader/random_access_reader.rs
@@ -13,10 +13,7 @@ use futures::{
 };
 
 use crate::{
-    condow_client::CondowClient,
-    config::Mebi,
-    errors::CondowError,
-    streams::{ChunkStream, OrderedChunkStream},
+    condow_client::CondowClient, config::Mebi, errors::CondowError, streams::OrderedChunkStream,
     Condow, DownloadRange,
 };
 
@@ -82,7 +79,7 @@ pub trait ReaderAdapter: Send + Sync + 'static {
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>>;
+    ) -> BoxFuture<'a, Result<OrderedChunkStream, CondowError>>;
 }
 
 pub(crate) struct CondowAdapter<C: CondowClient> {
@@ -107,7 +104,7 @@ where
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>> {
+    ) -> BoxFuture<'a, Result<OrderedChunkStream, CondowError>> {
         self.condow
             .blob()
             .range(range)

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -8,7 +8,7 @@ use futures::{future::BoxFuture, AsyncRead};
 
 use crate::{
     condow_client::IgnoreLocation, errors::CondowError, probe::Probe, reader::BytesAsyncReader,
-    ChunkStream, DownloadRange, GetSizeMode, PartStream,
+    ChunkStream, DownloadRange, GetSizeMode, OrderedChunkStream,
 };
 
 /// A function which downloads from the givel location and the given [Params].
@@ -110,7 +110,7 @@ impl<L> RequestNoLocation<L> {
 
 impl RequestNoLocation<IgnoreLocation> {
     /// Download as a [PartStream]
-    pub async fn download(self) -> Result<PartStream<ChunkStream>, CondowError> {
+    pub async fn download(self) -> Result<OrderedChunkStream<ChunkStream>, CondowError> {
         self.at(IgnoreLocation).download().await
     }
 
@@ -175,8 +175,8 @@ impl<L> Request<L> {
     }
 
     /// Download as a [PartStream]
-    pub async fn download(self) -> Result<PartStream<ChunkStream>, CondowError> {
-        PartStream::from_chunk_stream(self.download_chunks().await?)
+    pub async fn download(self) -> Result<OrderedChunkStream<ChunkStream>, CondowError> {
+        OrderedChunkStream::from_chunk_stream(self.download_chunks().await?)
     }
 
     /// Download as a [ChunkStream]

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -110,7 +110,7 @@ impl<L> RequestNoLocation<L> {
 
 impl RequestNoLocation<IgnoreLocation> {
     /// Download as a [PartStream]
-    pub async fn download(self) -> Result<OrderedChunkStream<ChunkStream>, CondowError> {
+    pub async fn download(self) -> Result<OrderedChunkStream, CondowError> {
         self.at(IgnoreLocation).download().await
     }
 
@@ -175,7 +175,7 @@ impl<L> Request<L> {
     }
 
     /// Download as a [PartStream]
-    pub async fn download(self) -> Result<OrderedChunkStream<ChunkStream>, CondowError> {
+    pub async fn download(self) -> Result<OrderedChunkStream, CondowError> {
         OrderedChunkStream::from_chunk_stream(self.download_chunks().await?)
     }
 

--- a/condow_core/src/streams/chunk_stream.rs
+++ b/condow_core/src/streams/chunk_stream.rs
@@ -8,8 +8,7 @@ use pin_project_lite::pin_project;
 
 use crate::{errors::CondowError, streams::ChunkStreamItem};
 
-use super::{BytesHint, OrderedChunkStream, Chunk};
-
+use super::{BytesHint, Chunk, OrderedChunkStream};
 
 pin_project! {
     /// A stream of [Chunk]s received from the network
@@ -156,7 +155,7 @@ impl ChunkStream {
     /// Turns this stream into a [PartStream]
     ///
     /// Fails if this [ChunkStream] was already iterated.
-    pub fn try_into_part_stream(self) -> Result<OrderedChunkStream<Self>, CondowError> {
+    pub fn try_into_part_stream(self) -> Result<OrderedChunkStream, CondowError> {
         OrderedChunkStream::try_from(self)
     }
 }

--- a/condow_core/src/streams/mod.rs
+++ b/condow_core/src/streams/mod.rs
@@ -1,7 +1,7 @@
 //! Stream implememtations used by Condow
 use std::fmt;
 
-use crate::errors::{IoError, CondowError};
+use crate::errors::{CondowError, IoError};
 use bytes::Bytes;
 use futures::stream::BoxStream;
 
@@ -23,7 +23,7 @@ pub type ChunkStreamItem = Result<Chunk, CondowError>;
 /// for a part with the same `part_index` but the chunks
 /// of different parts can be intermingled due
 /// to the nature of a concurrent download.
-/// 
+///
 /// If a download should be processed (bytewise) sequentially
 /// the chinks need to be ordered (see [OrderedChunkStream]).
 #[derive(Debug, Clone)]

--- a/condow_core/src/streams/mod.rs
+++ b/condow_core/src/streams/mod.rs
@@ -1,18 +1,66 @@
 //! Stream implememtations used by Condow
 use std::fmt;
 
-use crate::errors::IoError;
+use crate::errors::{IoError, CondowError};
 use bytes::Bytes;
 use futures::stream::BoxStream;
 
 mod chunk_stream;
-mod part_stream;
+mod ordered_chunk_stream;
 
 pub use chunk_stream::*;
-pub use part_stream::*;
+pub use ordered_chunk_stream::*;
 
 /// A stream of [Bytes] (chunks) where there can be an error for each chunk of bytes
 pub type BytesStream = BoxStream<'static, Result<Bytes, IoError>>;
+
+/// The type of the elements returned by a [ChunkStream]
+pub type ChunkStreamItem = Result<Chunk, CondowError>;
+
+/// A chunk belonging to a downloaded part
+///
+/// All chunks of a part will have the correct order
+/// for a part with the same `part_index` but the chunks
+/// of different parts can be intermingled due
+/// to the nature of a concurrent download.
+/// 
+/// If a download should be processed (bytewise) sequentially
+/// the chinks need to be ordered (see [OrderedChunkStream]).
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    /// Index of the part this chunk belongs to
+    pub part_index: u64,
+    /// Index of the chunk within the part
+    pub chunk_index: usize,
+    /// Offset of the chunk within the BLOB
+    pub blob_offset: u64,
+    /// Offset of the chunk within the downloaded range
+    pub range_offset: u64,
+    /// The bytes
+    pub bytes: Bytes,
+    /// Bytes left in following chunks of the same part. If 0 this is the last chunk of the part.
+    pub bytes_left: u64,
+}
+
+impl Chunk {
+    /// Returns `true` if this is the last chunk of the part
+    pub fn is_last(&self) -> bool {
+        self.bytes_left == 0
+    }
+
+    /// Returns the number of bytes in this chunk
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Returns `true` if there are no bytes in this chunk.
+    ///
+    /// This should not happen since we would not expect
+    /// "no bytes" being sent over the network.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 
 /// Returns the bounds on the remaining bytes of the stream.
 ///

--- a/condow_core/src/test_utils.rs
+++ b/condow_core/src/test_utils.rs
@@ -346,10 +346,13 @@ pub fn create_part_stream(
     n_chunks: usize,
     exact_hint: bool,
     max_variable_chunk_size: Option<usize>,
-) -> (OrderedChunkStream<ChunkStream>, Vec<u8>) {
+) -> (OrderedChunkStream, Vec<u8>) {
     let (stream, values) =
         create_chunk_stream(n_parts, n_chunks, exact_hint, max_variable_chunk_size);
-    (OrderedChunkStream::from_chunk_stream(stream).unwrap(), values)
+    (
+        OrderedChunkStream::from_chunk_stream(stream).unwrap(),
+        values,
+    )
 }
 
 #[tokio::test]
@@ -442,7 +445,7 @@ impl ReaderAdapter for TestDownloader {
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>> {
+    ) -> BoxFuture<'a, Result<OrderedChunkStream, CondowError>> {
         <TestDownloader as Downloads>::blob(self)
             .range(range)
             .download()

--- a/condow_core/src/test_utils.rs
+++ b/condow_core/src/test_utils.rs
@@ -15,7 +15,7 @@ use crate::{
     condow_client::{CondowClient, DownloadSpec, IgnoreLocation},
     errors::CondowError,
     reader::{RandomAccessReader, ReaderAdapter},
-    streams::{BytesHint, BytesStream, Chunk, ChunkStream, ChunkStreamItem, PartStream},
+    streams::{BytesHint, BytesStream, Chunk, ChunkStream, ChunkStreamItem, OrderedChunkStream},
     DownloadRange, Downloads, Params, RequestNoLocation,
 };
 
@@ -346,10 +346,10 @@ pub fn create_part_stream(
     n_chunks: usize,
     exact_hint: bool,
     max_variable_chunk_size: Option<usize>,
-) -> (PartStream<ChunkStream>, Vec<u8>) {
+) -> (OrderedChunkStream<ChunkStream>, Vec<u8>) {
     let (stream, values) =
         create_chunk_stream(n_parts, n_chunks, exact_hint, max_variable_chunk_size);
-    (PartStream::from_chunk_stream(stream).unwrap(), values)
+    (OrderedChunkStream::from_chunk_stream(stream).unwrap(), values)
 }
 
 #[tokio::test]
@@ -442,7 +442,7 @@ impl ReaderAdapter for TestDownloader {
     fn download_range<'a>(
         &'a self,
         range: DownloadRange,
-    ) -> BoxFuture<'a, Result<PartStream<ChunkStream>, CondowError>> {
+    ) -> BoxFuture<'a, Result<OrderedChunkStream<ChunkStream>, CondowError>> {
         <TestDownloader as Downloads>::blob(self)
             .range(range)
             .download()

--- a/condow_fs/CHANGELOG.md
+++ b/condow_fs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] -  2022-04-28
+
+### CHANGES
+
+- breaking changes in `condow_core`
+
 ## [0.14.0] -  2022-04-27
 
 ### CHANGES

--- a/condow_fs/Cargo.toml
+++ b/condow_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_fs"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -11,7 +11,7 @@ repository = "https://github.com/chridou/condow"
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.13", path = "../condow_core"}
+condow_core = { version = "0.14", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"

--- a/condow_rusoto/CHANGELOG.md
+++ b/condow_rusoto/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2022-04-28
+
+### CHANGED
+
+- Breaking changes in `condow_core`
+
 ## [0.14.0] - 2022-04-27
 
 ### CHANGED

--- a/condow_rusoto/Cargo.toml
+++ b/condow_rusoto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_rusoto"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -12,7 +12,7 @@ keywords = [ "AWS", "S3", "download", "parallel", "rusoto"]
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.13", path = "../condow_core"}
+condow_core = { version = "0.14", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"


### PR DESCRIPTION
Publish chunks to the clients instead of completely collected parts.


closes #45 