### PR TITLE
Remove getsizemode

### DIFF
--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.0 - 2022-05-01
+
+### CHANGED
+
+- Download requests can change the configuration for the requested download
+
+### REMOVED
+
+- **BREAKING** `GetSizeMode`
+
 ## 0.15.0 - 2022-04-29
 
 ### CHANGED

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_core"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/condow_core/src/condow_client.rs
+++ b/condow_core/src/condow_client.rs
@@ -145,12 +145,12 @@ mod in_memory {
     }
 
     impl<L> InMemoryClient<L> {
-        /// Blob from owned bytes
+        /// BLOB from owned bytes
         pub fn new(blob: Vec<u8>) -> Self {
             Self::new_shared(Arc::new(blob))
         }
 
-        /// Blob from shared bytes
+        /// BLOB from shared bytes
         pub fn new_shared(blob: Arc<Vec<u8>>) -> Self {
             Self {
                 blob: Blob::Owned(blob),
@@ -159,12 +159,12 @@ mod in_memory {
             }
         }
 
-        /// Blob copied from slice
+        /// BLOB copied from slice
         pub fn new_from_slice(blob: &[u8]) -> Self {
             Self::new(blob.to_vec())
         }
 
-        /// Blob with static byte slice
+        /// BLOB with static byte slice
         pub fn new_static(blob: &'static [u8]) -> Self {
             Self {
                 blob: Blob::Static(blob),

--- a/condow_core/src/condow_tests.rs
+++ b/condow_core/src/condow_tests.rs
@@ -163,12 +163,8 @@ mod range {
                         for from_idx in [0u64, 101, 255, 256] {
                             let range = from_idx..;
 
-                            let result_stream = condow
-                                .blob()
-                                .range(range)
-                                .download_chunks()
-                                .await
-                                .unwrap();
+                            let result_stream =
+                                condow.blob().range(range).download_chunks().await.unwrap();
 
                             let result = result_stream.into_vec().await.unwrap();
 
@@ -220,7 +216,7 @@ mod range {
                                 condow.config.clone(),
                                 IgnoreLocation,
                                 range.clone(),
-                               Default::default(),
+                                Default::default(),
                             )
                             .await
                             .unwrap();

--- a/condow_core/src/condow_tests.rs
+++ b/condow_core/src/condow_tests.rs
@@ -109,6 +109,7 @@ mod range {
                             .buffer_size(buffer_size)
                             .buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
+                            .always_get_size(true) // case to test
                             .max_concurrency(n_concurrency);
                         let condow = Condow::new(client.clone(), config).unwrap();
 
@@ -120,7 +121,6 @@ mod range {
                                 condow.config.clone(),
                                 IgnoreLocation,
                                 range.clone(),
-                                crate::GetSizeMode::Always,
                                 Default::default(),
                             )
                             .await
@@ -156,6 +156,7 @@ mod range {
                             .buffer_size(buffer_size)
                             .buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
+                            .always_get_size(false) // case to test
                             .max_concurrency(n_concurrency);
                         let condow = Condow::new(client.clone(), config).unwrap();
 
@@ -164,7 +165,6 @@ mod range {
 
                             let result_stream = condow
                                 .blob()
-                                .get_size_mode(crate::GetSizeMode::Required)
                                 .range(range)
                                 .download_chunks()
                                 .await
@@ -220,8 +220,7 @@ mod range {
                                 condow.config.clone(),
                                 IgnoreLocation,
                                 range.clone(),
-                                crate::GetSizeMode::Default,
-                                Default::default(),
+                               Default::default(),
                             )
                             .await
                             .unwrap();
@@ -267,7 +266,6 @@ mod range {
                                 condow.config.clone(),
                                 IgnoreLocation,
                                 range.clone(),
-                                crate::GetSizeMode::Default,
                                 Default::default(),
                             )
                             .await
@@ -323,7 +321,6 @@ mod range {
                                         condow.config.clone(),
                                         IgnoreLocation,
                                         range,
-                                        crate::GetSizeMode::Default,
                                         Default::default(),
                                     )
                                     .await
@@ -370,7 +367,6 @@ mod range {
                                         condow.config.clone(),
                                         IgnoreLocation,
                                         range,
-                                        crate::GetSizeMode::Default,
                                         Default::default(),
                                     )
                                     .await
@@ -428,7 +424,6 @@ mod range {
                                             condow.config.clone(),
                                             IgnoreLocation,
                                             range,
-                                            crate::GetSizeMode::Default,
                                             Default::default(),
                                         )
                                         .await
@@ -482,7 +477,6 @@ mod range {
                                             condow.config.clone(),
                                             IgnoreLocation,
                                             range,
-                                            crate::GetSizeMode::Default,
                                             Default::default(),
                                         )
                                         .await

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -314,7 +314,7 @@ where
                 (Some(req), Some(fac)) => ProbeInternal::Two(fac, req),
             };
 
-            machinery::download_range(condow.client, condow.config, location, params.range, probe)
+            machinery::download_range(condow.client, params.config, location, params.range, probe)
                 .boxed()
         };
 
@@ -404,7 +404,7 @@ where
                 (Some(req), Some(fac)) => ProbeInternal::Two(fac, req),
             };
 
-            machinery::download_range(condow.client, condow.config, location, params.range, probe)
+            machinery::download_range(condow.client, params.config, location, params.range, probe)
                 .boxed()
         };
 

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -86,7 +86,7 @@ use anyhow::Error as AnyError;
 use futures::{future::BoxFuture, FutureExt};
 
 use condow_client::CondowClient;
-use config::{AlwaysGetSize, ClientRetryWrapper, Config};
+use config::{ClientRetryWrapper, Config};
 use errors::CondowError;
 use machinery::ProbeInternal;
 use probe::{Probe, ProbeFactory};
@@ -117,7 +117,7 @@ pub mod test_utils;
 /// This trait is not object safe. If you want to use dynamic dispatch you
 /// might consider the trait [DownloadsUntyped] which is object safe
 /// and accepts string slices as a location.
-pub trait Downloads {
+pub trait Downloads: Send + Sync + 'static {
     type Location: std::fmt::Debug + std::fmt::Display + Clone + Send + Sync + 'static;
 
     /// Download a BLOB via the returned request object
@@ -185,7 +185,7 @@ pub trait Downloads {
 /// assert_eq!(blob, b"a remote BLOB");
 /// # }
 /// ```
-pub trait DownloadsUntyped {
+pub trait DownloadsUntyped: Send + Sync + 'static {
     /// Download a BLOB via the returned request object
     fn blob(&self) -> RequestNoLocation<&str>;
 
@@ -319,13 +319,12 @@ where
                 condow.config,
                 location,
                 params.range,
-                params.get_size_mode,
                 probe,
             )
             .boxed()
         };
 
-        RequestNoLocation::new(download_fn)
+        RequestNoLocation::new(download_fn, self.config.clone())
     }
 
     /// Get the size of a BLOB at the given location
@@ -416,13 +415,12 @@ where
                 condow.config,
                 location,
                 params.range,
-                params.get_size_mode,
                 probe,
             )
             .boxed()
         };
 
-        RequestNoLocation::new(download_fn)
+        RequestNoLocation::new(download_fn, self.config.clone())
     }
 
     fn get_size<'a>(&'a self, location: &str) -> BoxFuture<'a, Result<u64, CondowError>> {
@@ -459,38 +457,6 @@ where
         };
 
         Ok(self.reader_with_length(location, length))
-    }
-}
-
-/// Overide the behaviour when [Condow] does a request to get
-/// the size of a BLOB
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum GetSizeMode {
-    /// Request a size on open ranges and also closed ranges
-    /// so that a given upper bound can be adjusted/corrected
-    Always,
-    /// Only request the size of a BLOB when required. This is when an open
-    /// range (e.g. complete BLOB or from x to end)
-    Required,
-    /// As configured with [Condow] itself.
-    ///
-    /// This is the default value.
-    Default,
-}
-
-impl GetSizeMode {
-    fn is_load_size_enforced(self, always_by_default: AlwaysGetSize) -> bool {
-        match self {
-            GetSizeMode::Always => true,
-            GetSizeMode::Required => false,
-            GetSizeMode::Default => always_by_default.into_inner(),
-        }
-    }
-}
-
-impl Default for GetSizeMode {
-    fn default() -> Self {
-        Self::Default
     }
 }
 

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -314,14 +314,8 @@ where
                 (Some(req), Some(fac)) => ProbeInternal::Two(fac, req),
             };
 
-            machinery::download_range(
-                condow.client,
-                condow.config,
-                location,
-                params.range,
-                probe,
-            )
-            .boxed()
+            machinery::download_range(condow.client, condow.config, location, params.range, probe)
+                .boxed()
         };
 
         RequestNoLocation::new(download_fn, self.config.clone())
@@ -410,14 +404,8 @@ where
                 (Some(req), Some(fac)) => ProbeInternal::Two(fac, req),
             };
 
-            machinery::download_range(
-                condow.client,
-                condow.config,
-                location,
-                params.range,
-                probe,
-            )
-            .boxed()
+            machinery::download_range(condow.client, condow.config, location, params.range, probe)
+                .boxed()
         };
 
         RequestNoLocation::new(download_fn, self.config.clone())

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -10,7 +10,7 @@ use crate::config::{ClientRetryWrapper, Config};
 use crate::errors::{CondowError, IoError};
 use crate::streams::{BytesHint, ChunkStream};
 use crate::Probe;
-use crate::{DownloadRange, GetSizeMode, InclusiveRange};
+use crate::{DownloadRange, InclusiveRange};
 
 use self::range_stream::RangeStream;
 
@@ -22,7 +22,6 @@ pub(crate) async fn download_range<C: CondowClient, DR: Into<DownloadRange>, P: 
     config: Config,
     location: C::Location,
     range: DR,
-    get_size_mode: GetSizeMode,
     probe: ProbeInternal<P>,
 ) -> Result<ChunkStream, CondowError> {
     let range = range.into();
@@ -59,7 +58,7 @@ pub(crate) async fn download_range<C: CondowClient, DR: Into<DownloadRange>, P: 
         }
         DownloadRange::Closed(cl) => {
             debug!(parent: &get_stream_span, "closed range");
-            if get_size_mode.is_load_size_enforced(config.always_get_size) {
+            if config.always_get_size.into_inner() {
                 debug!(parent: &get_stream_span, "get size enforced");
                 let size = client.get_size(location.clone(), &probe).await?;
                 if let Some(range) = cl.incl_range_from_size(size) {

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -243,7 +243,7 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-           Default::default(),
+            Default::default(),
         )
         .await;
 

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -27,7 +27,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -62,7 +61,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -98,7 +96,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -134,7 +131,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -173,7 +169,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -210,7 +205,6 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
             Default::default(),
         )
         .await;
@@ -249,8 +243,7 @@ mod download {
             condow.config,
             IgnoreLocation,
             0..100,
-            crate::GetSizeMode::Required,
-            Default::default(),
+           Default::default(),
         )
         .await;
 

--- a/condow_core/src/reader/random_access_reader.rs
+++ b/condow_core/src/reader/random_access_reader.rs
@@ -116,6 +116,7 @@ where
             .blob()
             .range(range)
             .at(self.location.clone())
+            .reconfigure(|cfg| cfg.always_get_size(false)) // The reader has the size already
             .download()
             .boxed()
     }

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -105,7 +105,7 @@ impl<L> RequestNoLocation<L> {
         self
     }
 
-    /// Override the configuration
+    /// Override the configuration for this request
     pub fn reconfigure<F>(mut self, reconfigure: F) -> Self
     where
         F: FnOnce(Config) -> Config,
@@ -196,7 +196,7 @@ impl<L> Request<L> {
         self
     }
 
-    /// Override the configuration
+    /// Override the configuration for this request
     pub fn reconfigure<F>(mut self, reconfigure: F) -> Self
     where
         F: FnOnce(Config) -> Config,

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -10,8 +10,8 @@ use futures::{
 };
 
 use crate::{
-    condow_client::IgnoreLocation, errors::CondowError, probe::Probe, reader::BytesAsyncReader,
-    ChunkStream, DownloadRange, OrderedChunkStream, config::Config,
+    condow_client::IgnoreLocation, config::Config, errors::CondowError, probe::Probe,
+    reader::BytesAsyncReader, ChunkStream, DownloadRange, OrderedChunkStream,
 };
 
 /// A function which downloads from the given location and the given [Params].
@@ -106,7 +106,10 @@ impl<L> RequestNoLocation<L> {
     }
 
     /// Override the configuration
-    pub fn reconfigure<F>(mut self, reconfigure: F) -> Self where F: FnOnce(Config) -> Config {
+    pub fn reconfigure<F>(mut self, reconfigure: F) -> Self
+    where
+        F: FnOnce(Config) -> Config,
+    {
         self.params.config = reconfigure(self.params.config);
         self
     }
@@ -194,7 +197,10 @@ impl<L> Request<L> {
     }
 
     /// Override the configuration
-    pub fn reconfigure<F>(mut self, reconfigure: F) -> Self where F: FnOnce(Config) -> Config {
+    pub fn reconfigure<F>(mut self, reconfigure: F) -> Self
+    where
+        F: FnOnce(Config) -> Config,
+    {
         self.params.config = reconfigure(self.params.config);
         self
     }

--- a/condow_core/src/test_utils.rs
+++ b/condow_core/src/test_utils.rs
@@ -13,10 +13,11 @@ use tokio::time;
 
 use crate::{
     condow_client::{CondowClient, DownloadSpec, IgnoreLocation},
+    config::Config,
     errors::CondowError,
     reader::{RandomAccessReader, ReaderAdapter},
     streams::{BytesHint, BytesStream, Chunk, ChunkStream, ChunkStreamItem, OrderedChunkStream},
-    DownloadRange, Downloads, Params, RequestNoLocation, config::Config,
+    DownloadRange, Downloads, Params, RequestNoLocation,
 };
 
 #[derive(Clone)]

--- a/condow_fs/CHANGELOG.md
+++ b/condow_fs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] -  2022-05-01
+
+### CHANGES
+
+- breaking changes in `condow_core`
+
 ## [0.16.0] -  2022-04-29
 
 ### CHANGES

--- a/condow_fs/Cargo.toml
+++ b/condow_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_fs"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -11,7 +11,7 @@ repository = "https://github.com/chridou/condow"
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.15", path = "../condow_core"}
+condow_core = { version = "0.16", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"

--- a/condow_rusoto/CHANGELOG.md
+++ b/condow_rusoto/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] -  2022-05-01
+
+### CHANGES
+
+- breaking changes in `condow_core`
+
 ## [0.16.0] -  2022-04-29
 
 ### CHANGES

--- a/condow_rusoto/Cargo.toml
+++ b/condow_rusoto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_rusoto"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -12,7 +12,7 @@ keywords = [ "AWS", "S3", "download", "parallel", "rusoto"]
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.15", path = "../condow_core"}
+condow_core = { version = "0.16", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"


### PR DESCRIPTION
Removes `GetSizeMode` and makes it possible to change the configuration for each download individually. Also disable fetching the size in `RandomAccessReader`.

closes #51 