### PR TITLE
#56 fix prformance regresion

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [ "download", "network", "parallel", "files"]
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.16", path = "../condow_core"}
+condow_core = { version = "0.17", path = "../condow_core"}
 
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time", "rt-multi-thread"] }

--- a/benchmark/src/benchmarks.rs
+++ b/benchmark/src/benchmarks.rs
@@ -177,9 +177,8 @@ mod scenarios {
 
     impl Scenario {
         pub fn gen_downloader(&self) -> impl Downloads<Location = IgnoreLocation> {
-            let config = Config::default() //.buffers_full_delay_ms(1)
+            let config = Config::default()
                 .max_concurrency(self.max_concurrency)
-                //.buffer_size(1_000)
                 .part_size_bytes(self.part_size);
             let client = BenchmarkClient::new(self.blob_size, CHUNK_SIZE);
             client.condow(config).unwrap()

--- a/benchmark/src/benchmarks.rs
+++ b/benchmark/src/benchmarks.rs
@@ -205,7 +205,7 @@ mod chunk_stream_unordered {
 
     use condow_core::Downloads;
 
-    use super::{scenarios::Scenario, Benchmarks, Benchmark};
+    use super::{scenarios::Scenario, Benchmark, Benchmarks};
 
     pub async fn run(
         scenario: &Scenario,
@@ -291,7 +291,7 @@ mod chunk_stream_ordered {
     use futures::AsyncReadExt;
 
     use super::scenarios::{Scenario, CHUNK_SIZE};
-    use super::{Benchmarks, Benchmark};
+    use super::{Benchmark, Benchmarks};
 
     pub async fn run(
         scenario: &Scenario,
@@ -411,7 +411,7 @@ mod chunk_stream_ordered {
 }
 mod condow_client {
     //! Benchmarks for the client which delivers byte streams.
-    //! 
+    //!
     //! Ths is the [BenchmarkClient] used to deliver data for the other benchmarks
     use std::time::Instant;
 
@@ -422,7 +422,7 @@ mod condow_client {
 
     use super::{
         scenarios::{BLOB_SIZE, CHUNK_SIZE},
-        Benchmarks, Benchmark,
+        Benchmark, Benchmarks,
     };
 
     pub async fn run(benchmarks_collected: &mut Benchmarks) -> Result<(), anyhow::Error> {

--- a/benchmark/src/benchmarks.rs
+++ b/benchmark/src/benchmarks.rs
@@ -4,12 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use self::scenarios::gen_scenarios;
 
-pub async fn run() -> Result<Benchmarks, anyhow::Error> {
+pub async fn run(num_iterations: usize) -> Result<Benchmarks, anyhow::Error> {
     let mut benchmarks_collected = Benchmarks::new();
 
     let scenarios = gen_scenarios();
-
-    let num_iterations = 31;
 
     condow_client::run(&mut benchmarks_collected).await?;
     for scenario in scenarios {
@@ -430,7 +428,7 @@ mod condow_client {
     }
 
     async fn many_chunks(num_iterations: usize) -> Result<Benchmark, anyhow::Error> {
-        let mut results = Benchmark::new("client_get_chunks");
+        let mut results = Benchmark::new(format!("client_get_chunks_{:05}k", BLOB_SIZE / 1000));
 
         let client = BenchmarkClient::new(BLOB_SIZE, CHUNK_SIZE);
 

--- a/benchmark/src/benchmarks.rs
+++ b/benchmark/src/benchmarks.rs
@@ -50,10 +50,10 @@ pub struct Stats {
     #[serde(rename = "#")]
     pub index: usize,
     pub name: String,
+    pub avg_ms: f64,
     pub first_ms: f64,
     pub min_ms: f64,
     pub max_ms: f64,
-    pub avg_ms: f64,
 }
 
 impl Stats {

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use tokio::task::spawn_blocking;
+
 mod benchmarks;
 mod client;
 
@@ -7,11 +9,15 @@ mod client;
 async fn main() {
     let results = benchmarks::run().await.unwrap();
 
-    let mut wtr = csv::Writer::from_writer(io::stdout());
+    let handle = spawn_blocking(move || {
+        let mut wtr = csv::Writer::from_writer(io::stdout());
 
-    for stat in results.stats() {
-        wtr.serialize(stat).unwrap();
-    }
+        for stat in results.stats() {
+            wtr.serialize(stat).unwrap();
+        }
 
-    wtr.flush().unwrap();
+        wtr.flush().unwrap();
+    });
+
+    handle.await.unwrap();
 }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -7,7 +7,7 @@ mod client;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    let results = benchmarks::run().await.unwrap();
+    let results = benchmarks::run(51).await.unwrap();
 
     let handle = spawn_blocking(move || {
         let mut wtr = csv::Writer::from_writer(io::stdout());

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## unreleased
+## 0.17.0 - 2022-05-04
 
 ### CHANGED
 

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### CHANGED
+
+- **BREAKING** `BuffersFullDelayMs` became `MaxBuffersFullDelayMs`.
+
+### FIXED
+
+- performance issues
+
 ## 0.16.0 - 2022-05-01
 
 ### CHANGED

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.17.0 - 2022-05-04
+## 0.17.0 - 2022-05-05
 
 ### CHANGED
 

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_core"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/condow_core/examples/tracing.rs
+++ b/condow_core/examples/tracing.rs
@@ -65,7 +65,7 @@ async fn run() -> Result<(), Error> {
     let blob = (0u32..1_000).map(|x| x as u8).collect::<Vec<_>>();
 
     let config = Config::default()
-        .buffers_full_delay_ms(0)
+        .max_buffers_full_delay_ms(0)
         .part_size_bytes(13)
         .max_concurrency(2);
 

--- a/condow_core/src/condow_tests.rs
+++ b/condow_core/src/condow_tests.rs
@@ -27,7 +27,7 @@ mod blob {
                 for n_concurrency in [1usize, 10] {
                     let config = Config::default()
                         .buffer_size(buffer_size)
-                        .buffers_full_delay_ms(0)
+                        .max_buffers_full_delay_ms(0)
                         .part_size_bytes(part_size)
                         .max_concurrency(n_concurrency);
                     let condow = Condow::new(client.clone(), config).unwrap();
@@ -63,7 +63,7 @@ mod blob {
                 for n_concurrency in [1usize, 10] {
                     let config = Config::default()
                         .buffer_size(buffer_size)
-                        .buffers_full_delay_ms(0)
+                        .max_buffers_full_delay_ms(0)
                         .part_size_bytes(part_size)
                         .max_concurrency(n_concurrency);
                     let condow = Condow::new(client.clone(), config).unwrap();
@@ -107,7 +107,7 @@ mod range {
                     for n_concurrency in [1usize, 10] {
                         let config = Config::default()
                             .buffer_size(buffer_size)
-                            .buffers_full_delay_ms(0)
+                            .max_buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
                             .always_get_size(true) // case to test
                             .max_concurrency(n_concurrency);
@@ -154,7 +154,7 @@ mod range {
                     for n_concurrency in [1usize, 10] {
                         let config = Config::default()
                             .buffer_size(buffer_size)
-                            .buffers_full_delay_ms(0)
+                            .max_buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
                             .always_get_size(false) // case to test
                             .max_concurrency(n_concurrency);
@@ -202,7 +202,7 @@ mod range {
                     for n_concurrency in [1usize, 10] {
                         let config = Config::default()
                             .buffer_size(buffer_size)
-                            .buffers_full_delay_ms(0)
+                            .max_buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
                             .max_concurrency(n_concurrency);
                         let condow = Condow::new(client.clone(), config).unwrap();
@@ -248,7 +248,7 @@ mod range {
                     for n_concurrency in [1usize, 10] {
                         let config = Config::default()
                             .buffer_size(buffer_size)
-                            .buffers_full_delay_ms(0)
+                            .max_buffers_full_delay_ms(0)
                             .part_size_bytes(part_size)
                             .max_concurrency(n_concurrency);
                         let condow = Condow::new(client.clone(), config).unwrap();
@@ -302,7 +302,7 @@ mod range {
                             for n_concurrency in [1usize, 10] {
                                 let config = Config::default()
                                     .buffer_size(buffer_size)
-                                    .buffers_full_delay_ms(0)
+                                    .max_buffers_full_delay_ms(0)
                                     .part_size_bytes(part_size)
                                     .max_concurrency(n_concurrency);
                                 let condow = Condow::new(client.clone(), config).unwrap();
@@ -349,7 +349,7 @@ mod range {
                             for n_concurrency in [1usize, 10] {
                                 let config = Config::default()
                                     .buffer_size(buffer_size)
-                                    .buffers_full_delay_ms(0)
+                                    .max_buffers_full_delay_ms(0)
                                     .part_size_bytes(part_size)
                                     .max_concurrency(n_concurrency);
                                 let condow = Condow::new(client.clone(), config).unwrap();
@@ -403,7 +403,7 @@ mod range {
                             for n_concurrency in [1usize, 10] {
                                 let config = Config::default()
                                     .buffer_size(buffer_size)
-                                    .buffers_full_delay_ms(0)
+                                    .max_buffers_full_delay_ms(0)
                                     .part_size_bytes(part_size)
                                     .max_concurrency(n_concurrency);
                                 let condow = Condow::new(client.clone(), config).unwrap();
@@ -456,7 +456,7 @@ mod range {
                             for n_concurrency in [1usize, 10] {
                                 let config = Config::default()
                                     .buffer_size(buffer_size)
-                                    .buffers_full_delay_ms(0)
+                                    .max_buffers_full_delay_ms(0)
                                     .part_size_bytes(part_size)
                                     .max_concurrency(n_concurrency);
                                 let condow = Condow::new(client.clone(), config).unwrap();

--- a/condow_core/src/config.rs
+++ b/condow_core/src/config.rs
@@ -34,11 +34,11 @@ pub struct Config {
     ///
     /// Default is 2
     pub buffer_size: BufferSize,
-    /// If all buffers of all download tasks are full, this is the time
+    /// If all buffers of all download tasks are full, this is the maximum time
     /// to pause until the next attempt.
     ///
     /// Default is 10ms
-    pub buffers_full_delay_ms: BuffersFullDelayMs,
+    pub max_buffers_full_delay_ms: MaxBuffersFullDelayMs,
     /// If `true` [Condow](super::Condow) will also request the
     /// size information of a BLOB to verify the range supplied
     /// by a user.
@@ -74,13 +74,13 @@ impl Config {
         self
     }
 
-    /// Set the delay in case all task buffers are full before a retry
+    /// Set the maximum delay in case all task buffers are full before a retry
     /// to enqueue the next downlod part is made.
-    pub fn buffers_full_delay_ms<T: Into<BuffersFullDelayMs>>(
+    pub fn max_buffers_full_delay_ms<T: Into<MaxBuffersFullDelayMs>>(
         mut self,
-        buffers_full_delay_ms: T,
+        max_buffers_full_delay_ms: T,
     ) -> Self {
-        self.buffers_full_delay_ms = buffers_full_delay_ms.into();
+        self.max_buffers_full_delay_ms = max_buffers_full_delay_ms.into();
         self
     }
 
@@ -159,11 +159,11 @@ impl Config {
             found_any = true;
             self.buffer_size = buffer_size;
         }
-        if let Some(buffers_full_delay_ms) =
-            BuffersFullDelayMs::try_from_env_prefixed(prefix.as_ref())?
+        if let Some(max_buffers_full_delay_ms) =
+            MaxBuffersFullDelayMs::try_from_env_prefixed(prefix.as_ref())?
         {
             found_any = true;
-            self.buffers_full_delay_ms = buffers_full_delay_ms;
+            self.max_buffers_full_delay_ms = max_buffers_full_delay_ms;
         }
         if let Some(always_get_size) = AlwaysGetSize::try_from_env_prefixed(prefix.as_ref())? {
             found_any = true;
@@ -185,7 +185,7 @@ impl Default for Config {
             part_size_bytes: Default::default(),
             max_concurrency: Default::default(),
             buffer_size: Default::default(),
-            buffers_full_delay_ms: Default::default(),
+            max_buffers_full_delay_ms: Default::default(),
             always_get_size: Default::default(),
             retries: Some(Default::default()),
         }
@@ -380,19 +380,19 @@ impl Default for AlwaysGetSize {
 }
 
 new_type! {
-    #[doc="Time to wait for download buffers when all were full in ms"]
+    #[doc="Maximum time to wait for download buffers when all were full in ms"]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub copy struct BuffersFullDelayMs(u64, env="BUFFERS_FULL_DELAY_MS");
+    pub copy struct MaxBuffersFullDelayMs(u64, env="MAX_BUFFERS_FULL_DELAY_MS");
 }
 
-impl Default for BuffersFullDelayMs {
+impl Default for MaxBuffersFullDelayMs {
     fn default() -> Self {
         Self(10)
     }
 }
 
-impl From<BuffersFullDelayMs> for Duration {
-    fn from(m: BuffersFullDelayMs) -> Self {
+impl From<MaxBuffersFullDelayMs> for Duration {
+    fn from(m: MaxBuffersFullDelayMs) -> Self {
         Duration::from_millis(m.0)
     }
 }

--- a/condow_core/src/machinery/download/concurrent.rs
+++ b/condow_core/src/machinery/download/concurrent.rs
@@ -5,12 +5,12 @@ use std::{
     time::Instant,
 };
 
-use futures::{channel::mpsc::UnboundedSender, stream, StreamExt};
+use futures::{channel::mpsc::UnboundedSender, StreamExt};
 
 use crate::{
     condow_client::CondowClient,
     config::{ClientRetryWrapper, Config},
-    machinery::{range_stream::RangeRequest, DownloadSpanGuard, ProbeInternal},
+    machinery::{part_request::PartRequestIterator, DownloadSpanGuard, ProbeInternal},
     probe::Probe,
     streams::ChunkStreamItem,
 };
@@ -68,9 +68,9 @@ impl<P: Probe + Clone> ConcurrentDownloader<P> {
         }
     }
 
-    pub async fn download(&mut self, ranges: Vec<RangeRequest>) -> Result<(), ()> {
+    pub async fn download(&mut self, ranges: PartRequestIterator) -> Result<(), ()> {
         self.probe.download_started();
-        let mut ranges_stream = stream::iter(ranges.into_iter());
+        let mut ranges_stream = ranges.into_stream();
         while let Some(mut range_request) = ranges_stream.next().await {
             let mut attempt = 1;
 

--- a/condow_core/src/machinery/download/concurrent.rs
+++ b/condow_core/src/machinery/download/concurrent.rs
@@ -5,7 +5,7 @@ use std::{
     time::Instant,
 };
 
-use futures::{channel::mpsc::UnboundedSender, Stream, StreamExt};
+use futures::{channel::mpsc::UnboundedSender, stream, StreamExt};
 
 use crate::{
     condow_client::CondowClient,
@@ -68,12 +68,9 @@ impl<P: Probe + Clone> ConcurrentDownloader<P> {
         }
     }
 
-    pub async fn download(
-        &mut self,
-        ranges_stream: impl Stream<Item = RangeRequest>,
-    ) -> Result<(), ()> {
+    pub async fn download(&mut self, ranges: Vec<RangeRequest>) -> Result<(), ()> {
         self.probe.download_started();
-        let mut ranges_stream = Box::pin(ranges_stream);
+        let mut ranges_stream = stream::iter(ranges.into_iter());
         while let Some(mut range_request) = ranges_stream.next().await {
             let mut attempt = 1;
 

--- a/condow_core/src/machinery/download/concurrent/worker.rs
+++ b/condow_core/src/machinery/download/concurrent/worker.rs
@@ -1,0 +1,457 @@
+//! Download enqueued [RangeRequest]s sequentially
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
+
+use futures::{
+    channel::mpsc::{self, Sender, UnboundedSender},
+    StreamExt,
+};
+use tracing::{debug, debug_span, trace, Instrument, Span};
+
+use crate::{
+    condow_client::{CondowClient, DownloadSpec},
+    config::ClientRetryWrapper,
+    errors::{CondowError, IoError},
+    machinery::{part_request::PartRequest, DownloadSpanGuard, ProbeInternal},
+    probe::Probe,
+    streams::{BytesStream, Chunk, ChunkStreamItem},
+};
+
+use super::KillSwitch;
+
+/// Downloads equeued parts ([RangeRequest]s) of a download sequentially.
+///
+/// Spawns a task internally to process the parts to be downloaded one by one.
+/// The parts to be downloaded are enqueued in a channel.
+///
+/// Results are pushed into a channel via the [DownloaderContext].
+///
+/// Usually one `SequentialDownloader` is created for each level of
+/// concurrency.  
+pub(crate) struct SequentialDownloader {
+    request_sender: Sender<PartRequest>,
+}
+
+impl SequentialDownloader {
+    pub fn new<C: CondowClient, P: Probe + Clone>(
+        client: ClientRetryWrapper<C>,
+        location: C::Location,
+        buffer_size: usize,
+        mut context: DownloaderContext<P>,
+    ) -> Self {
+        let (request_sender, request_receiver) = mpsc::channel::<PartRequest>(buffer_size);
+
+        let download_span = context.span().clone();
+
+        tokio::spawn(
+            async move {
+                let mut request_receiver = Box::pin(request_receiver);
+                while let Some(range_request) = request_receiver.next().await {
+                    let span = debug_span!(
+                        parent: context.span(), "download_part", 
+                        part_index = %range_request.part_index,
+                        part_range = %range_request.blob_range,
+                        part_offset = %range_request.range_offset);
+
+                    if context.kill_switch.is_pushed() {
+                        // That failed task should have already sent an error...
+                        // ...but we do not want to prove that...
+                        context.send_err(CondowError::new_other(
+                            "another download task already failed",
+                        ));
+                        return;
+                    }
+
+                    match client
+                        .download(
+                            location.clone(),
+                            DownloadSpec::Range(range_request.blob_range),
+                            &context.probe,
+                        )
+                        .instrument(span.clone())
+                        .await
+                    {
+                        Ok((bytes_stream, _total_bytes)) => {
+                            if consume_and_dispatch_bytes(bytes_stream, &mut context, range_request)
+                                .instrument(span.clone())
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                        }
+                        Err(err) => {
+                            context.probe.part_failed(
+                                &err,
+                                range_request.part_index,
+                                &range_request.blob_range,
+                            );
+                            context.send_err(err);
+                            return;
+                        }
+                    };
+                }
+                context.mark_successful();
+                drop(context);
+            }
+            .instrument(download_span),
+        );
+
+        SequentialDownloader { request_sender }
+    }
+
+    pub fn enqueue(&mut self, req: PartRequest) -> Result<Option<PartRequest>, ()> {
+        match self.request_sender.try_send(req) {
+            Ok(()) => Ok(None),
+            Err(err) => {
+                if err.is_disconnected() {
+                    Err(())
+                } else {
+                    Ok(Some(err.into_inner()))
+                }
+            }
+        }
+    }
+}
+
+/// A context to control a [SequentialDownloader]
+///
+/// This has some logic on drop to do some cleanup and error tracking
+///
+/// Will abort the download vial the [KillSwitch] if the download of
+/// a part was not marked as completed.
+pub(crate) struct DownloaderContext<P: Probe + Clone> {
+    started_at: Instant,
+    counter: Arc<AtomicUsize>,
+    kill_switch: KillSwitch,
+    probe: ProbeInternal<P>,
+    results_sender: UnboundedSender<ChunkStreamItem>,
+    completed: bool,
+    /// This must exist for the whole download
+    download_span_guard: DownloadSpanGuard,
+}
+
+impl<P: Probe + Clone> DownloaderContext<P> {
+    pub fn new(
+        results_sender: UnboundedSender<ChunkStreamItem>,
+        counter: Arc<AtomicUsize>,
+        kill_switch: KillSwitch,
+        probe: ProbeInternal<P>,
+        started_at: Instant,
+        download_span_guard: DownloadSpanGuard,
+    ) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self {
+            counter,
+            probe,
+            kill_switch,
+            started_at,
+            results_sender,
+            completed: false,
+            download_span_guard,
+        }
+    }
+
+    pub fn send_chunk(&self, chunk: Chunk) -> Result<(), ()> {
+        if self.results_sender.unbounded_send(Ok(chunk)).is_ok() {
+            return Ok(());
+        }
+
+        self.kill_switch.push_the_button();
+
+        return Err(());
+    }
+
+    /// Send an error and mark as completed
+    pub fn send_err(&mut self, err: CondowError) {
+        let _ = self.results_sender.unbounded_send(Err(err));
+        self.completed = true;
+        self.kill_switch.push_the_button();
+    }
+
+    /// Mark the download as complete if successful
+    ///
+    /// This must be called upon successful termination of an [SequentialDownloader].
+    ///
+    /// If the download was not marked complete, an error will be sent when dropped
+    /// (a panic is assumed).
+    pub fn mark_successful(&mut self) {
+        self.completed = true;
+    }
+
+    pub fn span(&self) -> &Span {
+        self.download_span_guard.span()
+    }
+}
+
+impl<P: Probe + Clone> Drop for DownloaderContext<P> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.kill_switch.push_the_button();
+
+            let err = if std::thread::panicking() {
+                self.probe.panic_detected("panic detected in downloader");
+                CondowError::new_other("download ended unexpectedly due to a panic")
+            } else {
+                CondowError::new_other("download ended unexpectetly")
+            };
+            let _ = self.results_sender.unbounded_send(Err(err));
+        }
+
+        let remaining_contexts = self.counter.fetch_sub(1, Ordering::SeqCst);
+        trace!(parent: self.download_span_guard.span(), "dropping context ({remaining_contexts} contexts before drop)");
+
+        if self.counter.load(Ordering::SeqCst) == 0 {
+            if self.kill_switch.is_pushed() {
+                debug!(parent: self.download_span_guard.span(), "download failed");
+                self.probe.download_failed(Some(self.started_at.elapsed()))
+            } else {
+                debug!(parent: self.download_span_guard.span(), "download succeeded");
+                self.probe.download_completed(self.started_at.elapsed())
+            }
+        }
+    }
+}
+
+/// Read chunks of [Bytes] from a stream and dispatch them
+/// as [Chunk]s via the [DownloaderContext].
+///
+/// The [RangeRequest] is only passed for reporting purposes.
+///
+/// This function marks the [DownloaderContext] as complete via
+/// sending an error only.
+///
+/// [Bytes]: bytes::bytes
+async fn consume_and_dispatch_bytes<P: Probe + Clone>(
+    mut bytes_stream: BytesStream,
+    context: &mut DownloaderContext<P>,
+    range_request: PartRequest,
+) -> Result<(), ()> {
+    let mut chunk_index = 0;
+    let mut offset_in_range = 0;
+    let mut bytes_received = 0;
+    let bytes_expected = range_request.blob_range.len();
+    let part_start = Instant::now();
+    let mut chunk_start = Instant::now();
+
+    context
+        .probe
+        .part_started(range_request.part_index, range_request.blob_range);
+
+    while let Some(bytes_res) = bytes_stream.next().await {
+        match bytes_res {
+            Ok(bytes) => {
+                let t_chunk = chunk_start.elapsed();
+                chunk_start = Instant::now();
+                let n_bytes = bytes.len();
+                bytes_received += bytes.len() as u64;
+
+                trace!("received chunk of {} bytes (total {bytes_received} received of {bytes_expected})", bytes.len());
+
+                if bytes_received > bytes_expected {
+                    let err = CondowError::new_other(format!(
+                        "received more bytes than expected for part {} ({}..={}). expected {}, received {}",
+                        range_request.part_index,
+                        range_request.blob_range.start(),
+                        range_request.blob_range.end_incl(),
+                        range_request.blob_range.len(),
+                        bytes_received
+                    ));
+                    context.probe.part_failed(
+                        &err,
+                        range_request.part_index,
+                        &range_request.blob_range,
+                    );
+                    context.send_err(err);
+                    return Err(());
+                }
+
+                context.probe.chunk_completed(
+                    range_request.part_index,
+                    chunk_index,
+                    n_bytes,
+                    t_chunk,
+                );
+
+                context.send_chunk(Chunk {
+                    part_index: range_request.part_index,
+                    chunk_index,
+                    blob_offset: range_request.blob_range.start() + offset_in_range,
+                    range_offset: range_request.range_offset + offset_in_range,
+                    bytes,
+                    bytes_left: bytes_expected - bytes_received,
+                })?;
+                chunk_index += 1;
+                offset_in_range += n_bytes as u64;
+            }
+            Err(IoError(msg)) => {
+                context.probe.part_failed(
+                    &CondowError::new_io(msg.clone()),
+                    range_request.part_index,
+                    &range_request.blob_range,
+                );
+                context.send_err(CondowError::new_io(msg));
+                return Err(());
+            }
+        }
+    }
+
+    context.probe.part_completed(
+        range_request.part_index,
+        chunk_index,
+        bytes_received,
+        part_start.elapsed(),
+    );
+
+    if bytes_received != bytes_expected {
+        let err = CondowError::new_other(format!(
+            "received wrong number of bytes for part {} ({}..={}). expected {}, received {}",
+            range_request.part_index,
+            range_request.blob_range.start(),
+            range_request.blob_range.end_incl(),
+            range_request.blob_range.len(),
+            bytes_received
+        ));
+        context
+            .probe
+            .part_failed(&err, range_request.part_index, &range_request.blob_range);
+        let _ = context.send_err(err);
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{atomic::AtomicUsize, Arc},
+        time::Instant,
+    };
+
+    use futures::StreamExt;
+    use tracing::Span;
+
+    use crate::{
+        condow_client::{
+            failing_client_simulator::FailingClientSimulatorBuilder, CondowClient, IgnoreLocation,
+        },
+        config::Config,
+        errors::{CondowError, CondowErrorKind},
+        machinery::{
+            download::{
+                concurrent::worker::{DownloaderContext, SequentialDownloader},
+                KillSwitch,
+            },
+            part_request::PartRequestIterator,
+            DownloadSpanGuard,
+        },
+        streams::{BytesHint, Chunk, ChunkStream},
+        test_utils::*,
+        InclusiveRange,
+    };
+
+    #[tokio::test]
+    async fn from_0_to_inclusive_range_larger_than_part_size() {
+        let client = TestCondowClient::new().max_chunk_size(3);
+
+        for range in [
+            InclusiveRange(0, 8),
+            InclusiveRange(0, 9),
+            InclusiveRange(0, 10),
+        ] {
+            check(range, client.clone(), 10).await.unwrap()
+        }
+    }
+
+    #[tokio::test]
+    async fn failing_request() {
+        let blob = (0u8..100).collect::<Vec<_>>();
+        let client = FailingClientSimulatorBuilder::default()
+            .blob(blob)
+            .chunk_size(100)
+            .responses()
+            .failure(CondowErrorKind::Other)
+            .finish();
+
+        assert!(check(InclusiveRange(0, 99), client, 100).await.is_err());
+    }
+
+    async fn check<C: CondowClient<Location = IgnoreLocation>>(
+        range: InclusiveRange,
+        client: C,
+        part_size_bytes: u64,
+    ) -> Result<(), CondowError> {
+        let config = Config::default()
+            .buffer_size(10)
+            .max_buffers_full_delay_ms(0)
+            .part_size_bytes(part_size_bytes)
+            .max_concurrency(1); // Won't work otherwise
+
+        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+
+        let mut ranges_stream =
+            PartRequestIterator::new(range, config.part_size_bytes.into()).into_stream();
+
+        let (result_stream, results_sender) = ChunkStream::new(bytes_hint);
+
+        let mut downloader = SequentialDownloader::new(
+            client.into(),
+            IgnoreLocation,
+            config.buffer_size.into(),
+            DownloaderContext::new(
+                results_sender,
+                Arc::new(AtomicUsize::new(0)),
+                KillSwitch::new(),
+                Default::default(),
+                Instant::now(),
+                DownloadSpanGuard::new(Span::none()),
+            ),
+        );
+
+        while let Some(next) = ranges_stream.next().await {
+            let _ = downloader.enqueue(next).unwrap();
+        }
+
+        drop(downloader); // Ends the stream
+
+        let result = result_stream.collect::<Vec<_>>().await;
+        let result = result.into_iter().collect::<Result<Vec<_>, _>>()?;
+
+        let total_bytes: u64 = result.iter().map(|c| c.bytes.len() as u64).sum();
+        assert_eq!(total_bytes, range.len(), "total_bytes");
+
+        let mut next_range_offset = 0;
+        let mut next_blob_offset = range.start();
+
+        result.iter().for_each(|c| {
+            let Chunk {
+                part_index,
+                blob_offset,
+                range_offset,
+                bytes,
+                ..
+            } = c;
+            assert_eq!(
+                *range_offset, next_range_offset,
+                "part {}, range_offset: {:?}",
+                part_index, range
+            );
+            assert_eq!(
+                *blob_offset, next_blob_offset,
+                "part {}, blob_offset: {:?}",
+                part_index, range
+            );
+            next_range_offset += bytes.len() as u64;
+            next_blob_offset += bytes.len() as u64;
+        });
+
+        Ok(())
+    }
+}

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -1,4 +1,6 @@
 //! Perform the actual download
+//!
+//! Downloads can be done concurrently or sequentially.
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -20,6 +22,9 @@ use super::{part_request::PartRequestIterator, DownloadSpanGuard, ProbeInternal}
 mod concurrent;
 mod sequential;
 
+/// Download the chunks concurrently
+///
+/// This has more overhead than downloading sequentially.
 pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
     ranges: PartRequestIterator,
     n_concurrent: usize,
@@ -43,6 +48,9 @@ pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
     .await
 }
 
+/// Download the chunks sequentially.
+///
+/// This has less overhead than dowloading concurrently.
 pub(crate) async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
     part_requests: PartRequestIterator,
     client: ClientRetryWrapper<C>,

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -10,18 +10,16 @@ use futures::channel::mpsc::UnboundedSender;
 use crate::{
     condow_client::CondowClient,
     config::{ClientRetryWrapper, Config},
+    errors::CondowError,
     probe::Probe,
-    streams::ChunkStreamItem,
+    streams::{Chunk, ChunkStreamItem},
 };
-
-use self::concurrent::ConcurrentDownloader;
 
 use super::{part_request::PartRequestIterator, DownloadSpanGuard, ProbeInternal};
 
 mod concurrent;
 mod sequential;
 
-/// Download the parst of a BLOB concurrently
 pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
     ranges: PartRequestIterator,
     n_concurrent: usize,
@@ -32,17 +30,28 @@ pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
     probe: ProbeInternal<P>,
     download_span_guard: DownloadSpanGuard,
 ) -> Result<(), ()> {
-    let mut downloader = ConcurrentDownloader::new(
+    self::concurrent::download_concurrently(
+        ranges,
         n_concurrent,
         results_sender,
         client,
-        config.clone(),
+        config,
         location,
         probe,
         download_span_guard,
-    );
+    )
+    .await
+}
 
-    downloader.download(ranges).await
+pub(crate) async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
+    part_requests: PartRequestIterator,
+    client: ClientRetryWrapper<C>,
+    location: C::Location,
+    probe: ProbeInternal<P>,
+    sender: UnboundedSender<Result<Chunk, CondowError>>,
+) {
+    self::sequential::download_chunks_sequentially(part_requests, client, location, probe, sender)
+        .await
 }
 
 /// Shared state to control cancellation of a download

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -23,7 +23,7 @@ mod sequential;
 
 /// Download the parst of a BLOB concurrently
 pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
-    ranges_stream: impl Stream<Item = RangeRequest>,
+    ranges: Vec<RangeRequest>,
     n_concurrent: usize,
     results_sender: UnboundedSender<ChunkStreamItem>,
     client: ClientRetryWrapper<C>,
@@ -42,7 +42,7 @@ pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
         download_span_guard,
     );
 
-    downloader.download(ranges_stream).await
+    downloader.download(ranges).await
 }
 
 /// Shared state to control cancellation of a download

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc,
 };
 
-use futures::{channel::mpsc::UnboundedSender, Stream};
+use futures::channel::mpsc::UnboundedSender;
 
 use crate::{
     condow_client::CondowClient,
@@ -16,14 +16,14 @@ use crate::{
 
 use self::concurrent::ConcurrentDownloader;
 
-use super::{range_stream::RangeRequest, DownloadSpanGuard, ProbeInternal};
+use super::{part_request::PartRequestIterator, DownloadSpanGuard, ProbeInternal};
 
 mod concurrent;
 mod sequential;
 
 /// Download the parst of a BLOB concurrently
 pub(crate) async fn download_concurrently<C: CondowClient, P: Probe + Clone>(
-    ranges: Vec<RangeRequest>,
+    ranges: PartRequestIterator,
     n_concurrent: usize,
     results_sender: UnboundedSender<ChunkStreamItem>,
     client: ClientRetryWrapper<C>,

--- a/condow_core/src/machinery/download/sequential.rs
+++ b/condow_core/src/machinery/download/sequential.rs
@@ -390,7 +390,7 @@ mod tests {
     ) -> Result<(), CondowError> {
         let config = Config::default()
             .buffer_size(10)
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(part_size_bytes)
             .max_concurrency(1); // Won't work otherwise
 

--- a/condow_core/src/machinery/download/sequential.rs
+++ b/condow_core/src/machinery/download/sequential.rs
@@ -1,457 +1,95 @@
-//! Download enqueued [RangeRequest]s sequentially
+use std::time::Instant;
 
-use std::{
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    time::Instant,
-};
-
-use futures::{
-    channel::mpsc::{self, Sender, UnboundedSender},
-    StreamExt,
-};
-use tracing::{debug, debug_span, trace, Instrument, Span};
+use futures::channel::mpsc::UnboundedSender;
+use futures::{StreamExt, TryStreamExt};
 
 use crate::{
-    condow_client::{CondowClient, DownloadSpec},
+    condow_client::CondowClient,
     config::ClientRetryWrapper,
-    errors::{CondowError, IoError},
-    machinery::{part_request::PartRequest, DownloadSpanGuard, ProbeInternal},
+    errors::CondowError,
+    machinery::{part_request::PartRequestIterator, ProbeInternal},
     probe::Probe,
-    streams::{BytesStream, Chunk, ChunkStreamItem},
+    streams::Chunk,
 };
 
-use super::KillSwitch;
-
-/// Downloads equeued parts ([RangeRequest]s) of a download sequentially.
-///
-/// Spawns a task internally to process the parts to be downloaded one by one.
-/// The parts to be downloaded are enqueued in a channel.
-///
-/// Results are pushed into a channel via the [DownloaderContext].
-///
-/// Usually one `SequentialDownloader` is created for each level of
-/// concurrency.  
-pub(crate) struct SequentialDownloader {
-    request_sender: Sender<PartRequest>,
-}
-
-impl SequentialDownloader {
-    pub fn new<C: CondowClient, P: Probe + Clone>(
-        client: ClientRetryWrapper<C>,
-        location: C::Location,
-        buffer_size: usize,
-        mut context: DownloaderContext<P>,
-    ) -> Self {
-        let (request_sender, request_receiver) = mpsc::channel::<PartRequest>(buffer_size);
-
-        let download_span = context.span().clone();
-
-        tokio::spawn(
-            async move {
-                let mut request_receiver = Box::pin(request_receiver);
-                while let Some(range_request) = request_receiver.next().await {
-                    let span = debug_span!(
-                        parent: context.span(), "download_part", 
-                        part_index = %range_request.part_index,
-                        part_range = %range_request.blob_range,
-                        part_offset = %range_request.range_offset);
-
-                    if context.kill_switch.is_pushed() {
-                        // That failed task should have already sent an error...
-                        // ...but we do not want to prove that...
-                        context.send_err(CondowError::new_other(
-                            "another download task already failed",
-                        ));
+pub(crate) async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
+    part_requests: PartRequestIterator,
+    client: ClientRetryWrapper<C>,
+    location: C::Location,
+    probe: ProbeInternal<P>,
+    sender: UnboundedSender<Result<Chunk, CondowError>>,
+) {
+    probe.download_started();
+    let download_started_at = Instant::now();
+    for part_request in part_requests {
+        let part_started_at = Instant::now();
+        probe.part_started(part_request.part_index, part_request.blob_range);
+        let (stream, _bytes_hint) = client
+            .download(location.clone(), part_request.blob_range.into(), &probe)
+            .await
+            .unwrap();
+        let mut chunk_index = 0;
+        let mut range_offset = part_request.range_offset;
+        let mut blob_offset = part_request.blob_range.start();
+        let mut bytes_left = part_request.blob_range.len();
+        let mut stream = stream
+            .map_ok(|bytes| {
+                let bytes_len = bytes.len() as u64;
+                bytes_left -= bytes_len;
+                let chunk = Chunk {
+                    part_index: part_request.part_index,
+                    chunk_index,
+                    blob_offset,
+                    range_offset,
+                    bytes,
+                    bytes_left,
+                };
+                chunk_index += 1;
+                blob_offset += bytes_len;
+                range_offset += bytes_len;
+                chunk
+            })
+            .map_err(Into::into);
+        let mut n_chunks = 0;
+        let mut chunk_started_at = Instant::now();
+        while let Some(chunk_result) = stream.next().await {
+            match chunk_result {
+                Ok(chunk) => {
+                    probe.chunk_completed(
+                        part_request.part_index,
+                        chunk.chunk_index,
+                        chunk.bytes.len(),
+                        chunk_started_at.elapsed(),
+                    );
+                    chunk_started_at = Instant::now();
+                    n_chunks += 1;
+                    let send_result = sender
+                        .unbounded_send(Ok(chunk))
+                        .map_err(|e| CondowError::new_io(e.to_string()));
+                    if let Err(err) = send_result {
+                        probe.part_failed(&err, part_request.part_index, &part_request.blob_range);
+                        probe.download_failed(Some(download_started_at.elapsed()));
                         return;
                     }
-
-                    match client
-                        .download(
-                            location.clone(),
-                            DownloadSpec::Range(range_request.blob_range),
-                            &context.probe,
-                        )
-                        .instrument(span.clone())
-                        .await
-                    {
-                        Ok((bytes_stream, _total_bytes)) => {
-                            if consume_and_dispatch_bytes(bytes_stream, &mut context, range_request)
-                                .instrument(span.clone())
-                                .await
-                                .is_err()
-                            {
-                                return;
-                            }
-                        }
-                        Err(err) => {
-                            context.probe.part_failed(
-                                &err,
-                                range_request.part_index,
-                                &range_request.blob_range,
-                            );
-                            context.send_err(err);
-                            return;
-                        }
-                    };
                 }
-                context.mark_successful();
-                drop(context);
-            }
-            .instrument(download_span),
-        );
-
-        SequentialDownloader { request_sender }
-    }
-
-    pub fn enqueue(&mut self, req: PartRequest) -> Result<Option<PartRequest>, ()> {
-        match self.request_sender.try_send(req) {
-            Ok(()) => Ok(None),
-            Err(err) => {
-                if err.is_disconnected() {
-                    Err(())
-                } else {
-                    Ok(Some(err.into_inner()))
-                }
-            }
-        }
-    }
-}
-
-/// A context to control a [SequentialDownloader]
-///
-/// This has some logic on drop to do some cleanup and error tracking
-///
-/// Will abort the download vial the [KillSwitch] if the download of
-/// a part was not marked as completed.
-pub(crate) struct DownloaderContext<P: Probe + Clone> {
-    started_at: Instant,
-    counter: Arc<AtomicUsize>,
-    kill_switch: KillSwitch,
-    probe: ProbeInternal<P>,
-    results_sender: UnboundedSender<ChunkStreamItem>,
-    completed: bool,
-    /// This must exist for the whole download
-    download_span_guard: DownloadSpanGuard,
-}
-
-impl<P: Probe + Clone> DownloaderContext<P> {
-    pub fn new(
-        results_sender: UnboundedSender<ChunkStreamItem>,
-        counter: Arc<AtomicUsize>,
-        kill_switch: KillSwitch,
-        probe: ProbeInternal<P>,
-        started_at: Instant,
-        download_span_guard: DownloadSpanGuard,
-    ) -> Self {
-        counter.fetch_add(1, Ordering::SeqCst);
-        Self {
-            counter,
-            probe,
-            kill_switch,
-            started_at,
-            results_sender,
-            completed: false,
-            download_span_guard,
-        }
-    }
-
-    pub fn send_chunk(&self, chunk: Chunk) -> Result<(), ()> {
-        if self.results_sender.unbounded_send(Ok(chunk)).is_ok() {
-            return Ok(());
-        }
-
-        self.kill_switch.push_the_button();
-
-        return Err(());
-    }
-
-    /// Send an error and mark as completed
-    pub fn send_err(&mut self, err: CondowError) {
-        let _ = self.results_sender.unbounded_send(Err(err));
-        self.completed = true;
-        self.kill_switch.push_the_button();
-    }
-
-    /// Mark the download as complete if successful
-    ///
-    /// This must be called upon successful termination of an [SequentialDownloader].
-    ///
-    /// If the download was not marked complete, an error will be sent when dropped
-    /// (a panic is assumed).
-    pub fn mark_successful(&mut self) {
-        self.completed = true;
-    }
-
-    pub fn span(&self) -> &Span {
-        self.download_span_guard.span()
-    }
-}
-
-impl<P: Probe + Clone> Drop for DownloaderContext<P> {
-    fn drop(&mut self) {
-        if !self.completed {
-            self.kill_switch.push_the_button();
-
-            let err = if std::thread::panicking() {
-                self.probe.panic_detected("panic detected in downloader");
-                CondowError::new_other("download ended unexpectedly due to a panic")
-            } else {
-                CondowError::new_other("download ended unexpectetly")
-            };
-            let _ = self.results_sender.unbounded_send(Err(err));
-        }
-
-        let remaining_contexts = self.counter.fetch_sub(1, Ordering::SeqCst);
-        trace!(parent: self.download_span_guard.span(), "dropping context ({remaining_contexts} contexts before drop)");
-
-        if self.counter.load(Ordering::SeqCst) == 0 {
-            if self.kill_switch.is_pushed() {
-                debug!(parent: self.download_span_guard.span(), "download failed");
-                self.probe.download_failed(Some(self.started_at.elapsed()))
-            } else {
-                debug!(parent: self.download_span_guard.span(), "download succeeded");
-                self.probe.download_completed(self.started_at.elapsed())
-            }
-        }
-    }
-}
-
-/// Read chunks of [Bytes] from a stream and dispatch them
-/// as [Chunk]s via the [DownloaderContext].
-///
-/// The [RangeRequest] is only passed for reporting purposes.
-///
-/// This function marks the [DownloaderContext] as complete via
-/// sending an error only.
-///
-/// [Bytes]: bytes::bytes
-async fn consume_and_dispatch_bytes<P: Probe + Clone>(
-    mut bytes_stream: BytesStream,
-    context: &mut DownloaderContext<P>,
-    range_request: PartRequest,
-) -> Result<(), ()> {
-    let mut chunk_index = 0;
-    let mut offset_in_range = 0;
-    let mut bytes_received = 0;
-    let bytes_expected = range_request.blob_range.len();
-    let part_start = Instant::now();
-    let mut chunk_start = Instant::now();
-
-    context
-        .probe
-        .part_started(range_request.part_index, range_request.blob_range);
-
-    while let Some(bytes_res) = bytes_stream.next().await {
-        match bytes_res {
-            Ok(bytes) => {
-                let t_chunk = chunk_start.elapsed();
-                chunk_start = Instant::now();
-                let n_bytes = bytes.len();
-                bytes_received += bytes.len() as u64;
-
-                trace!("received chunk of {} bytes (total {bytes_received} received of {bytes_expected})", bytes.len());
-
-                if bytes_received > bytes_expected {
-                    let err = CondowError::new_other(format!(
-                        "received more bytes than expected for part {} ({}..={}). expected {}, received {}",
-                        range_request.part_index,
-                        range_request.blob_range.start(),
-                        range_request.blob_range.end_incl(),
-                        range_request.blob_range.len(),
-                        bytes_received
-                    ));
-                    context.probe.part_failed(
-                        &err,
-                        range_request.part_index,
-                        &range_request.blob_range,
+                Err(chunk_error) => {
+                    probe.part_failed(
+                        &chunk_error,
+                        part_request.part_index,
+                        &part_request.blob_range,
                     );
-                    context.send_err(err);
-                    return Err(());
+                    probe.download_failed(Some(download_started_at.elapsed()));
+                    sender.unbounded_send(Err(chunk_error)).ok();
+                    return;
                 }
-
-                context.probe.chunk_completed(
-                    range_request.part_index,
-                    chunk_index,
-                    n_bytes,
-                    t_chunk,
-                );
-
-                context.send_chunk(Chunk {
-                    part_index: range_request.part_index,
-                    chunk_index,
-                    blob_offset: range_request.blob_range.start() + offset_in_range,
-                    range_offset: range_request.range_offset + offset_in_range,
-                    bytes,
-                    bytes_left: bytes_expected - bytes_received,
-                })?;
-                chunk_index += 1;
-                offset_in_range += n_bytes as u64;
-            }
-            Err(IoError(msg)) => {
-                context.probe.part_failed(
-                    &CondowError::new_io(msg.clone()),
-                    range_request.part_index,
-                    &range_request.blob_range,
-                );
-                context.send_err(CondowError::new_io(msg));
-                return Err(());
             }
         }
-    }
-
-    context.probe.part_completed(
-        range_request.part_index,
-        chunk_index,
-        bytes_received,
-        part_start.elapsed(),
-    );
-
-    if bytes_received != bytes_expected {
-        let err = CondowError::new_other(format!(
-            "received wrong number of bytes for part {} ({}..={}). expected {}, received {}",
-            range_request.part_index,
-            range_request.blob_range.start(),
-            range_request.blob_range.end_incl(),
-            range_request.blob_range.len(),
-            bytes_received
-        ));
-        context
-            .probe
-            .part_failed(&err, range_request.part_index, &range_request.blob_range);
-        let _ = context.send_err(err);
-        Err(())
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        sync::{atomic::AtomicUsize, Arc},
-        time::Instant,
-    };
-
-    use futures::StreamExt;
-    use tracing::Span;
-
-    use crate::{
-        condow_client::{
-            failing_client_simulator::FailingClientSimulatorBuilder, CondowClient, IgnoreLocation,
-        },
-        config::Config,
-        errors::{CondowError, CondowErrorKind},
-        machinery::{
-            download::{
-                sequential::{DownloaderContext, SequentialDownloader},
-                KillSwitch,
-            },
-            part_request::PartRequestIterator,
-            DownloadSpanGuard,
-        },
-        streams::{BytesHint, Chunk, ChunkStream},
-        test_utils::*,
-        InclusiveRange,
-    };
-
-    #[tokio::test]
-    async fn from_0_to_inclusive_range_larger_than_part_size() {
-        let client = TestCondowClient::new().max_chunk_size(3);
-
-        for range in [
-            InclusiveRange(0, 8),
-            InclusiveRange(0, 9),
-            InclusiveRange(0, 10),
-        ] {
-            check(range, client.clone(), 10).await.unwrap()
-        }
-    }
-
-    #[tokio::test]
-    async fn failing_request() {
-        let blob = (0u8..100).collect::<Vec<_>>();
-        let client = FailingClientSimulatorBuilder::default()
-            .blob(blob)
-            .chunk_size(100)
-            .responses()
-            .failure(CondowErrorKind::Other)
-            .finish();
-
-        assert!(check(InclusiveRange(0, 99), client, 100).await.is_err());
-    }
-
-    async fn check<C: CondowClient<Location = IgnoreLocation>>(
-        range: InclusiveRange,
-        client: C,
-        part_size_bytes: u64,
-    ) -> Result<(), CondowError> {
-        let config = Config::default()
-            .buffer_size(10)
-            .max_buffers_full_delay_ms(0)
-            .part_size_bytes(part_size_bytes)
-            .max_concurrency(1); // Won't work otherwise
-
-        let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
-
-        let mut ranges_stream =
-            PartRequestIterator::new(range, config.part_size_bytes.into()).into_stream();
-
-        let (result_stream, results_sender) = ChunkStream::new(bytes_hint);
-
-        let mut downloader = SequentialDownloader::new(
-            client.into(),
-            IgnoreLocation,
-            config.buffer_size.into(),
-            DownloaderContext::new(
-                results_sender,
-                Arc::new(AtomicUsize::new(0)),
-                KillSwitch::new(),
-                Default::default(),
-                Instant::now(),
-                DownloadSpanGuard::new(Span::none()),
-            ),
+        probe.part_completed(
+            part_request.part_index,
+            n_chunks,
+            part_request.blob_range.len(),
+            part_started_at.elapsed(),
         );
-
-        while let Some(next) = ranges_stream.next().await {
-            let _ = downloader.enqueue(next).unwrap();
-        }
-
-        drop(downloader); // Ends the stream
-
-        let result = result_stream.collect::<Vec<_>>().await;
-        let result = result.into_iter().collect::<Result<Vec<_>, _>>()?;
-
-        let total_bytes: u64 = result.iter().map(|c| c.bytes.len() as u64).sum();
-        assert_eq!(total_bytes, range.len(), "total_bytes");
-
-        let mut next_range_offset = 0;
-        let mut next_blob_offset = range.start();
-
-        result.iter().for_each(|c| {
-            let Chunk {
-                part_index,
-                blob_offset,
-                range_offset,
-                bytes,
-                ..
-            } = c;
-            assert_eq!(
-                *range_offset, next_range_offset,
-                "part {}, range_offset: {:?}",
-                part_index, range
-            );
-            assert_eq!(
-                *blob_offset, next_blob_offset,
-                "part {}, blob_offset: {:?}",
-                part_index, range
-            );
-            next_range_offset += bytes.len() as u64;
-            next_blob_offset += bytes.len() as u64;
-        });
-
-        Ok(())
     }
+    probe.download_completed(download_started_at.elapsed());
 }

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -1,22 +1,21 @@
 //! Streams for handling downloads
 use std::fmt;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use futures::channel::mpsc::UnboundedSender;
-use futures::{StreamExt, TryStreamExt};
 use tracing::{debug, info, info_span, Span};
 
 use crate::condow_client::CondowClient;
 use crate::config::{ClientRetryWrapper, Config};
 use crate::errors::{CondowError, IoError};
-use crate::streams::{BytesHint, Chunk, ChunkStream};
+use crate::streams::{BytesHint, ChunkStream};
 use crate::Probe;
 use crate::{DownloadRange, InclusiveRange};
 
 use self::part_request::PartRequestIterator;
 
 mod download;
+
 mod part_request;
 
 pub(crate) async fn download_range<C: CondowClient, DR: Into<DownloadRange>, P: Probe + Clone>(
@@ -120,7 +119,7 @@ async fn download_chunks<C: CondowClient, P: Probe + Clone>(
         .into_inner()
         .min(part_requests.exact_size_hint() as usize);
     if effective_concurrency == 1 {
-        tokio::spawn(download_chunks_sequentially(
+        tokio::spawn(download::download_chunks_sequentially(
             part_requests,
             client,
             location,
@@ -145,88 +144,6 @@ async fn download_chunks<C: CondowClient, P: Probe + Clone>(
     }
 
     Ok(chunk_stream)
-}
-
-async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
-    part_requests: PartRequestIterator,
-    client: ClientRetryWrapper<C>,
-    location: C::Location,
-    probe: ProbeInternal<P>,
-    sender: UnboundedSender<Result<Chunk, CondowError>>,
-) {
-    probe.download_started();
-    let download_started_at = Instant::now();
-    for part_request in part_requests {
-        let part_started_at = Instant::now();
-        probe.part_started(part_request.part_index, part_request.blob_range);
-        let (stream, _bytes_hint) = client
-            .download(location.clone(), part_request.blob_range.into(), &probe)
-            .await
-            .unwrap();
-        let mut chunk_index = 0;
-        let mut range_offset = part_request.range_offset;
-        let mut blob_offset = part_request.blob_range.start();
-        let mut bytes_left = part_request.blob_range.len();
-        let mut stream = stream
-            .map_ok(|bytes| {
-                let bytes_len = bytes.len() as u64;
-                bytes_left -= bytes_len;
-                let chunk = Chunk {
-                    part_index: part_request.part_index,
-                    chunk_index,
-                    blob_offset,
-                    range_offset,
-                    bytes,
-                    bytes_left,
-                };
-                chunk_index += 1;
-                blob_offset += bytes_len;
-                range_offset += bytes_len;
-                chunk
-            })
-            .map_err(Into::into);
-        let mut n_chunks = 0;
-        let mut chunk_started_at = Instant::now();
-        while let Some(chunk_result) = stream.next().await {
-            match chunk_result {
-                Ok(chunk) => {
-                    probe.chunk_completed(
-                        part_request.part_index,
-                        chunk.chunk_index,
-                        chunk.bytes.len(),
-                        chunk_started_at.elapsed(),
-                    );
-                    chunk_started_at = Instant::now();
-                    n_chunks += 1;
-                    let send_result = sender
-                        .unbounded_send(Ok(chunk))
-                        .map_err(|e| CondowError::new_io(e.to_string()));
-                    if let Err(err) = send_result {
-                        probe.part_failed(&err, part_request.part_index, &part_request.blob_range);
-                        probe.download_failed(Some(download_started_at.elapsed()));
-                        return;
-                    }
-                }
-                Err(chunk_error) => {
-                    probe.part_failed(
-                        &chunk_error,
-                        part_request.part_index,
-                        &part_request.blob_range,
-                    );
-                    probe.download_failed(Some(download_started_at.elapsed()));
-                    sender.unbounded_send(Err(chunk_error)).ok();
-                    return;
-                }
-            }
-        }
-        probe.part_completed(
-            part_request.part_index,
-            n_chunks,
-            part_request.blob_range.len(),
-            part_started_at.elapsed(),
-        );
-    }
-    probe.download_completed(download_started_at.elapsed());
 }
 
 /// This struct contains a span which must be kept alive until whole download is completed

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -164,7 +164,7 @@ async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
             .await
             .unwrap();
         let mut chunk_index = 0;
-        let mut range_offset = 0;
+        let mut range_offset = part_request.range_offset;
         let mut blob_offset = part_request.blob_range.start();
         let mut bytes_left = part_request.blob_range.len();
         let mut stream = stream

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -167,7 +167,6 @@ async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
         let mut stream = stream
             .map_ok(|bytes| {
                 let bytes_len = bytes.len() as u64;
-                bytes_left -= bytes_len;
                 let chunk = Chunk {
                     part_index: part_request.part_index,
                     chunk_index,
@@ -179,13 +178,13 @@ async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
                 chunk_index += 1;
                 blob_offset += bytes_len;
                 range_offset += bytes_len;
+                bytes_left -= bytes_len;
                 chunk
             })
             .map_err(Into::into);
-        while let Some(chunk_or_error) = stream.next().await {
-            let received_error = chunk_or_error.is_err();
-            if sender.unbounded_send(chunk_or_error).is_err() || received_error {
-                return;
+        while let Some(next) = stream.next().await {
+            if sender.unbounded_send(next).is_err() {
+                break;
             }
         }
     }

--- a/condow_core/src/machinery/part_request.rs
+++ b/condow_core/src/machinery/part_request.rs
@@ -2,11 +2,11 @@ use futures::Stream;
 
 use crate::InclusiveRange;
 
-/// A request to downlaod a range.
+/// A request to download a part.
 ///
-/// This is usually a part of a download.
+/// This is a part a download is split into.
 #[derive(Debug)]
-pub struct RangeRequest {
+pub struct PartRequest {
     /// Index of the part
     pub part_index: u64,
     /// The range to be downloaded from the BLOB.
@@ -16,51 +16,77 @@ pub struct RangeRequest {
 }
 
 #[cfg(test)]
-impl RangeRequest {
+impl PartRequest {
+    /// Returns the length of the part in bytes
     pub fn len(&self) -> u64 {
         self.blob_range.len()
     }
 }
 
-pub struct RangeStream;
+/// An [Iterator] over all the parts required to complete a download.
+pub struct PartRequestIterator {
+    start: u64,
+    part_size: u64,
+    next_range_offset: u64,
+    next_part_index: u64,
+    parts_left: u64,
+    end_incl: u64,
+}
 
-impl RangeStream {
-    pub fn create(
-        range: InclusiveRange,
-        part_size: u64,
-    ) -> (u64, impl Stream<Item = RangeRequest>) {
+impl PartRequestIterator {
+    pub fn new(range: InclusiveRange, part_size: u64) -> Self {
         if part_size == 0 {
-            panic!("part_size must not be 0. This is a bug.");
+            panic!("part_size must not be 0. This is a bug somewhere else.");
         }
 
-        let mut start = range.start();
-        let mut next_range_offset = 0;
+        Self {
+            start: range.start(),
+            part_size,
+            next_range_offset: 0,
+            next_part_index: 0,
+            parts_left: calc_num_parts(range, part_size),
+            end_incl: range.end_incl(),
+        }
+    }
 
-        let num_parts = calc_num_parts(range, part_size);
+    pub fn exact_size_hint(&self) -> u64 {
+        self.parts_left
+    }
 
-        let mut counter = 0;
-        let iter = std::iter::from_fn(move || {
-            if start > range.end_incl() {
-                return None;
-            }
+    /// Turns this iterator into a [Stream]
+    pub fn into_stream(self) -> impl Stream<Item = PartRequest> {
+        futures::stream::iter(self)
+    }
+}
 
-            let current_end_incl = (start + part_size - 1).min(range.end_incl());
-            let blob_range = InclusiveRange(start, current_end_incl);
-            start = current_end_incl + 1;
+impl Iterator for PartRequestIterator {
+    type Item = PartRequest;
 
-            let res = Some(RangeRequest {
-                part_index: counter,
-                blob_range,
-                range_offset: next_range_offset,
-            });
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start > self.end_incl {
+            return None;
+        }
 
-            next_range_offset += blob_range.len();
-            counter += 1;
+        let current_end_incl = (self.start + self.part_size - 1).min(self.end_incl);
+        let blob_range = InclusiveRange(self.start, current_end_incl);
+        self.start = current_end_incl + 1;
 
-            res
-        });
+        let request = PartRequest {
+            part_index: self.next_part_index,
+            blob_range,
+            range_offset: self.next_range_offset,
+        };
 
-        (num_parts, futures::stream::iter(iter))
+        self.next_range_offset += blob_range.len();
+        self.next_part_index += 1;
+
+        self.parts_left -= 1;
+
+        Some(request)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.parts_left as usize, Some(self.parts_left as usize))
     }
 }
 
@@ -188,17 +214,16 @@ fn test_calc_num_parts() {
     // assert_eq!(calc_num_parts(part_size, start, end_incl), 0, "size={} start={}, end_incl={}", part_size, start, end_incl);
 }
 
-#[tokio::test]
-async fn test_n_parts_vs_stream_count() {
-    use futures::StreamExt as _;
-
+#[test]
+fn test_n_parts_vs_iter_count() {
     for part_size in 1..50 {
         for start in 0..50 {
             for end_offset in 0..50 {
                 let end_incl = start + end_offset;
                 let range = InclusiveRange(start, end_incl);
-                let (n_parts, stream) = RangeStream::create(range, part_size);
-                let items = stream.collect::<Vec<_>>().await;
+                let iter = PartRequestIterator::new(range, part_size);
+                let n_parts = iter.exact_size_hint();
+                let items = iter.collect::<Vec<_>>();
 
                 assert_eq!(
                     items.len() as u64,

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -11,7 +11,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(2)
             .disable_retries();
@@ -43,7 +43,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(2)
             .disable_retries();
@@ -78,7 +78,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(2)
             .disable_retries();
@@ -113,7 +113,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(2)
             .disable_retries();
@@ -149,7 +149,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(1)
             .configure_retries(|rc| rc.max_attempts(1).initial_delay_ms(0));
@@ -187,7 +187,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(2)
             .disable_retries();
@@ -223,7 +223,7 @@ mod download {
         let blob = (0u8..100).collect::<Vec<_>>();
 
         let config = Config::default()
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(1)
             .configure_retries(|rc| rc.max_attempts(1).initial_delay_ms(0));
@@ -277,7 +277,7 @@ mod download_chunks {
 
         let config = Config::default()
             .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(1);
 
@@ -309,7 +309,7 @@ mod download_chunks {
 
         let config = Config::default()
             .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(1);
 
@@ -341,7 +341,7 @@ mod download_chunks {
 
         let config = Config::default()
             .buffer_size(buffer_size)
-            .buffers_full_delay_ms(0)
+            .max_buffers_full_delay_ms(0)
             .part_size_bytes(10)
             .max_concurrency(1);
 

--- a/condow_core/src/streams/chunk_stream.rs
+++ b/condow_core/src/streams/chunk_stream.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{channel::mpsc, ready, Stream, StreamExt, TryStreamExt, future};
+use futures::{channel::mpsc, future, ready, Stream, StreamExt, TryStreamExt};
 use pin_project_lite::pin_project;
 
 use crate::{errors::CondowError, streams::ChunkStreamItem};
@@ -163,7 +163,8 @@ impl ChunkStream {
     ///
     /// Provided mainly for testing.
     pub async fn count_bytes(self) -> Result<u64, CondowError> {
-        self.try_fold(0u64, |acc, chunk| future::ok(acc + chunk.len() as u64)).await
+        self.try_fold(0u64, |acc, chunk| future::ok(acc + chunk.len() as u64))
+            .await
     }
 }
 

--- a/condow_core/src/streams/mod.rs
+++ b/condow_core/src/streams/mod.rs
@@ -31,14 +31,26 @@ pub struct Chunk {
     /// Index of the part this chunk belongs to
     pub part_index: u64,
     /// Index of the chunk within the part
+    ///
+    /// For each new part this must start with zero.
     pub chunk_index: usize,
-    /// Offset of the chunk within the BLOB
+    /// Offset of the chunk within the (original) BLOB
+    ///
+    /// This value can be used to reconstruct a BLOB consisting of multiple
+    /// downloads. E.g. if there is a buffer which has the size of the original
+    /// BLOB this would be the offset to put the bytes of this chunk.
     pub blob_offset: u64,
     /// Offset of the chunk within the downloaded range
+    ///
+    /// This can be used to reconstruct the range of the BLOB which was downloaded.
+    /// E.g. if there is a buffer which has the size of the downloaded range
+    /// this would be the offset to put the bytes of this chunk.
     pub range_offset: u64,
     /// The bytes
     pub bytes: Bytes,
     /// Bytes left in following chunks of the same part. If 0 this is the last chunk of the part.
+    ///
+    /// This is the bytes left excluding the number of bytes of the current chunk.
     pub bytes_left: u64,
 }
 

--- a/condow_core/src/streams/ordered_chunk_stream.rs
+++ b/condow_core/src/streams/ordered_chunk_stream.rs
@@ -7,7 +7,7 @@ use std::{
 use bytes::Bytes;
 use futures::{
     channel::mpsc::{self, UnboundedReceiver},
-    ready, Stream, StreamExt, TryStreamExt, future,
+    future, ready, Stream, StreamExt, TryStreamExt,
 };
 use pin_project_lite::pin_project;
 
@@ -131,7 +131,8 @@ impl OrderedChunkStream {
     ///
     /// Provided mainly for testing.
     pub async fn count_bytes(self) -> Result<u64, CondowError> {
-        self.try_fold(0u64, |acc, chunk| future::ok(acc + chunk.len() as u64)).await
+        self.try_fold(0u64, |acc, chunk| future::ok(acc + chunk.len() as u64))
+            .await
     }
 
     pub fn bytes_stream(

--- a/condow_fs/CHANGELOG.md
+++ b/condow_fs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] -  2022-05-04
+
+### CHANGES
+
+- breaking changes in `condow_core`
+
 ## [0.17.0] -  2022-05-01
 
 ### CHANGES

--- a/condow_fs/CHANGELOG.md
+++ b/condow_fs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] -  2022-05-04
+## [0.18.0] -  2022-05-05
 
 ### CHANGES
 

--- a/condow_fs/Cargo.toml
+++ b/condow_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_fs"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -11,7 +11,7 @@ repository = "https://github.com/chridou/condow"
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.16", path = "../condow_core"}
+condow_core = { version = "0.17", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"

--- a/condow_rusoto/CHANGELOG.md
+++ b/condow_rusoto/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] -  2022-05-04
+
+### CHANGES
+
+- breaking changes in `condow_core`
 ## [0.17.0] -  2022-05-01
 
 ### CHANGES

--- a/condow_rusoto/CHANGELOG.md
+++ b/condow_rusoto/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] -  2022-05-04
+## [0.18.0] -  2022-05-05
 
 ### CHANGES
 

--- a/condow_rusoto/Cargo.toml
+++ b/condow_rusoto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_rusoto"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -12,7 +12,7 @@ keywords = [ "AWS", "S3", "download", "parallel", "rusoto"]
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "0.16", path = "../condow_core"}
+condow_core = { version = "0.17", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"


### PR DESCRIPTION
Improves the performance.

Also measures throughput in the benchmarks.

There is a breaking change which renamed the config value `BuffersFullDelayMs` to `MaxBuffersFullDelayMs` (see docs).

Also non concurrent downloads run an own code path which has less overhead. 

closes #56
