### PR TITLE
#61 control concurrency for small downloads

### DIFF
--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### ADDED
+
+- config parameter `LogDownloadMessagesAsDebug` to configure log level of outer doenload events
+- config parameters `MinPartsForConcurrentDownload`, `MinBytesForConcurrentDownload` and `SequentialDownloadMode` to configure sequential downloads
 ## 0.17.1 - 2022-05-12
 
 ### CHANGED

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - config parameter `LogDownloadMessagesAsDebug` to configure log level of outer doenload events
 - config parameters `MinPartsForConcurrentDownload`, `MinBytesForConcurrentDownload` and `SequentialDownloadMode` to configure sequential downloads
+
 ## 0.17.1 - 2022-05-12
 
 ### CHANGED

--- a/condow_core/src/condow_client.rs
+++ b/condow_core/src/condow_client.rs
@@ -70,6 +70,9 @@ impl From<RangeInclusive<u64>> for DownloadSpec {
 /// partial downloads
 ///
 /// This is an adapter trait
+///
+/// Implementors of this trait may not panic on calling any of the methods nor
+/// within any of the futures returned.
 pub trait CondowClient: Clone + Send + Sync + 'static {
     type Location: std::fmt::Debug + std::fmt::Display + Clone + Send + Sync + 'static;
 

--- a/condow_core/src/config.rs
+++ b/condow_core/src/config.rs
@@ -5,11 +5,13 @@
 //! This is mainly to allow them to be
 //! initialized from the environment.
 use std::{
+    ops,
     str::{from_utf8, FromStr},
     time::Duration,
 };
 
 use anyhow::{bail, Error as AnyError};
+use tracing::{debug, info};
 
 pub use crate::retry::*;
 
@@ -27,6 +29,19 @@ pub struct Config {
     /// than `max_concurrency` are to be
     /// downloaded
     pub max_concurrency: MaxConcurrency,
+    /// The minimum number of parts a download must consist of for the parts to be downloaded concurrently.
+    /// Depending on the part sizes it might be more efficient to set a number higer than 2. Downloading concurrently has an overhead.
+    /// This setting plays together with `MinBytesForConcurrentDownload`.
+    /// Setting this value to 0 or 1 makes no sense and has no effect.
+    /// The default is 2.
+    pub min_parts_for_concurrent_download: MinPartsForConcurrentDownload,
+    /// The minimum number of bytes a download must consist of for the parts to be downloaded concurrently.
+    /// Downloading concurrently has an overhead so it can make sens to set this value greater that `PART_SIZE_BYTES`.
+    ///
+    /// This setting plays together with `MinPartsForConcurrentDownload`.
+    ///
+    /// The default is 0.
+    pub min_bytes_for_concurrent_download: MinBytesForConcurrentDownload,
     /// Size of the buffer for each download task.
     ///
     /// If set to 0 (not advised) there will be now buffer at all.
@@ -45,6 +60,13 @@ pub struct Config {
     ///
     /// The default is `true`.
     pub always_get_size: AlwaysGetSize,
+    /// If set to `true` download related messages are logged at `DEBUG` level. Otherwise at `INFO` level.
+    ///
+    /// The affectd messages are:
+    /// * `Download started`
+    /// * `Download completed`
+    /// * `Download failed`
+    pub log_download_messages_as_debug: LogDownloadMessagesAsDebug,
     /// Configures retries if there.
     ///
     /// Otherwise there won't be any retry attempts made
@@ -68,6 +90,32 @@ impl Config {
         self
     }
 
+    /// The minimum number of parts a download must consist of for the parts to be downloaded concurrently.
+    /// Depending on the part sizes it might be more efficient to set a number higer than 2. Downloading concurrently has an overhead.
+    /// This setting plays together with `MinBytesForConcurrentDownload`.
+    /// Setting this value to 0 or 1 makes no sense and has no effect.
+    /// The default is 2.
+    pub fn min_parts_for_concurrent_download<T: Into<MinPartsForConcurrentDownload>>(
+        mut self,
+        min_parts_for_concurrent_download: T,
+    ) -> Self {
+        self.min_parts_for_concurrent_download = min_parts_for_concurrent_download.into();
+        self
+    }
+    /// The minimum number of bytes a download must consist of for the parts to be downloaded concurrently.
+    /// Downloading concurrently has an overhead so it can make sens to set this value greater that `PART_SIZE_BYTES`.
+    ///
+    /// This setting plays together with `MinPartsForConcurrentDownload`.
+    ///
+    /// The default is 0.
+    pub fn min_bytes_for_concurrent_download<T: Into<MinBytesForConcurrentDownload>>(
+        mut self,
+        min_bytes_for_concurrent_download: T,
+    ) -> Self {
+        self.min_bytes_for_concurrent_download = min_bytes_for_concurrent_download.into();
+        self
+    }
+
     /// Set the size of the buffer for each download task.
     pub fn buffer_size<T: Into<BufferSize>>(mut self, buffer_size: T) -> Self {
         self.buffer_size = buffer_size.into();
@@ -87,6 +135,20 @@ impl Config {
     /// Set whether a size request should always be made
     pub fn always_get_size<T: Into<AlwaysGetSize>>(mut self, always_get_size: T) -> Self {
         self.always_get_size = always_get_size.into();
+        self
+    }
+
+    /// If set to `true` download related messages are logged at `DEBUG` level. Otherwise at `INFO` level.
+    ///
+    /// The affectd messages are:
+    /// * `download started`
+    /// * `download completed`
+    /// * `download failed`
+    pub fn log_download_messages_as_debug<T: Into<LogDownloadMessagesAsDebug>>(
+        mut self,
+        log_download_messages_as_debug: T,
+    ) -> Self {
+        self.log_download_messages_as_debug = log_download_messages_as_debug.into();
         self
     }
 
@@ -155,6 +217,18 @@ impl Config {
             found_any = true;
             self.max_concurrency = max_concurrency;
         }
+        if let Some(min_parts_for_concurrent_download) =
+            MinPartsForConcurrentDownload::try_from_env_prefixed(prefix.as_ref())?
+        {
+            found_any = true;
+            self.min_parts_for_concurrent_download = min_parts_for_concurrent_download;
+        }
+        if let Some(min_bytes_for_concurrent_download) =
+            MinBytesForConcurrentDownload::try_from_env_prefixed(prefix.as_ref())?
+        {
+            found_any = true;
+            self.min_bytes_for_concurrent_download = min_bytes_for_concurrent_download;
+        }
         if let Some(buffer_size) = BufferSize::try_from_env_prefixed(prefix.as_ref())? {
             found_any = true;
             self.buffer_size = buffer_size;
@@ -168,6 +242,13 @@ impl Config {
         if let Some(always_get_size) = AlwaysGetSize::try_from_env_prefixed(prefix.as_ref())? {
             found_any = true;
             self.always_get_size = always_get_size;
+        }
+
+        if let Some(log_download_messages_as_debug) =
+            LogDownloadMessagesAsDebug::try_from_env_prefixed(prefix.as_ref())?
+        {
+            found_any = true;
+            self.log_download_messages_as_debug = log_download_messages_as_debug;
         }
 
         if let Some(retries) = RetryConfig::from_env_prefixed(prefix.as_ref())? {
@@ -184,9 +265,12 @@ impl Default for Config {
         Self {
             part_size_bytes: Default::default(),
             max_concurrency: Default::default(),
+            min_bytes_for_concurrent_download: Default::default(),
+            min_parts_for_concurrent_download: Default::default(),
             buffer_size: Default::default(),
             max_buffers_full_delay_ms: Default::default(),
             always_get_size: Default::default(),
+            log_download_messages_as_debug: Default::default(),
             retries: Some(Default::default()),
         }
     }
@@ -253,6 +337,20 @@ impl PartSizeBytes {
     env_funs!("PART_SIZE_BYTES");
 }
 
+impl ops::Deref for PartSizeBytes {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for PartSizeBytes {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl Default for PartSizeBytes {
     fn default() -> Self {
         PartSizeBytes::new(Mebi(4))
@@ -311,29 +409,33 @@ impl FromStr for PartSizeBytes {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
-        if let Some(idx) = s.find(|c: char| c.is_alphabetic()) {
-            if idx == 0 {
-                bail!("'{}' needs digits", s)
-            }
+        parse_dimension(s).map(PartSizeBytes)
+    }
+}
 
-            let digits = from_utf8(&s.as_bytes()[..idx])?.trim();
-            let unit = from_utf8(&s.as_bytes()[idx..])?.trim();
-
-            let bytes = digits.parse::<u64>()?;
-
-            match unit {
-                "k" => Ok(Kilo(bytes).into()),
-                "M" => Ok(Mega(bytes).into()),
-                "G" => Ok(Giga(bytes).into()),
-                "Ki" => Ok(Kibi(bytes).into()),
-                "Mi" => Ok(Mebi(bytes).into()),
-                "Gi" => Ok(Gibi(bytes).into()),
-                s => bail!("invalid unit: '{}'", s),
-            }
-        } else {
-            Ok(Self::new(s.parse::<u64>()?))
+fn parse_dimension(s: &str) -> Result<u64, anyhow::Error> {
+    let s = s.trim();
+    if let Some(idx) = s.find(|c: char| c.is_alphabetic()) {
+        if idx == 0 {
+            bail!("'{}' needs digits", s)
         }
+
+        let digits = from_utf8(&s.as_bytes()[..idx])?.trim();
+        let unit = from_utf8(&s.as_bytes()[idx..])?.trim();
+
+        let bytes = digits.parse::<u64>()?;
+
+        match unit {
+            "k" => Ok(Kilo(bytes).into()),
+            "M" => Ok(Mega(bytes).into()),
+            "G" => Ok(Giga(bytes).into()),
+            "Ki" => Ok(Kibi(bytes).into()),
+            "Mi" => Ok(Mebi(bytes).into()),
+            "Gi" => Ok(Gibi(bytes).into()),
+            s => bail!("invalid unit: '{}'", s),
+        }
+    } else {
+        Ok(s.parse::<u64>()?)
     }
 }
 
@@ -368,6 +470,164 @@ impl Default for BufferSize {
 }
 
 new_type! {
+    #[doc="The minimum number of parts a download must consist of for the parts to be downloaded concurrently"]
+    #[doc="Depending on the part sizes it might be more efficient to set a number higer than 2. Downloading concurrently has an overhead."]
+    #[doc="This setting plays together with `MinBytesForConcurrentDownload`."]
+    #[doc="Setting this value to 0 or 1 makes no sense and has no effect."]
+    #[doc="The default is 2."]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub copy struct MinPartsForConcurrentDownload(u64, env="MIN_PARTS_FOR_CONCURRENT_DOWNLOAD");
+}
+
+impl Default for MinPartsForConcurrentDownload {
+    fn default() -> Self {
+        MinPartsForConcurrentDownload(2)
+    }
+}
+
+/// The minimum number of bytes a download must consist of for the parts to be downloaded concurrently.
+/// Downloading concurrently has an overhead so it can make sens to set this value greater that `PART_SIZE_BYTES`.
+///
+/// This setting plays together with `MinPartsForConcurrentDownload`.
+///
+/// The default is 0.
+///
+/// # Examples
+///
+/// ### Parsing
+/// ```rust
+/// # use condow_core::config::MinBytesForConcurrentDownload;
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "34".parse().unwrap();
+/// assert_eq!(n_bytes, 34.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1k".parse().unwrap();
+/// assert_eq!(n_bytes, 1_000.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1 k".parse().unwrap();
+/// assert_eq!(n_bytes, 1_000.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1M".parse().unwrap();
+/// assert_eq!(n_bytes, 1_000_000.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1G".parse().unwrap();
+/// assert_eq!(n_bytes, 1_000_000_000.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1Ki".parse().unwrap();
+/// assert_eq!(n_bytes, 1_024.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1Mi".parse().unwrap();
+/// assert_eq!(n_bytes, 1_048_576.into());
+///
+/// let n_bytes: MinBytesForConcurrentDownload = "1Gi".parse().unwrap();
+/// assert_eq!(n_bytes, 1_073_741_824.into());
+///
+/// // Case sensitive
+/// let res = "1K".parse::<MinBytesForConcurrentDownload>();
+/// assert!(res.is_err());
+///
+/// let res = "x".parse::<MinBytesForConcurrentDownload>();
+/// assert!(res.is_err());
+///
+/// let res = "".parse::<MinBytesForConcurrentDownload>();
+/// assert!(res.is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MinBytesForConcurrentDownload(u64);
+
+impl MinBytesForConcurrentDownload {
+    pub fn new<T: Into<u64>>(part_size_bytes: T) -> Self {
+        Self(part_size_bytes.into())
+    }
+
+    pub const fn from_u64(part_size_bytes: u64) -> Self {
+        Self(part_size_bytes)
+    }
+
+    pub const fn into_inner(self) -> u64 {
+        self.0
+    }
+
+    env_funs!("MIN_BYTES_FOR_CONCURRENT_DOWNLOAD");
+}
+
+impl ops::Deref for MinBytesForConcurrentDownload {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for MinBytesForConcurrentDownload {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Default for MinBytesForConcurrentDownload {
+    fn default() -> Self {
+        MinBytesForConcurrentDownload::new(0u64)
+    }
+}
+
+impl From<u64> for MinBytesForConcurrentDownload {
+    fn from(v: u64) -> Self {
+        MinBytesForConcurrentDownload(v)
+    }
+}
+
+impl From<MinBytesForConcurrentDownload> for u64 {
+    fn from(v: MinBytesForConcurrentDownload) -> Self {
+        v.0
+    }
+}
+
+impl From<Kilo> for MinBytesForConcurrentDownload {
+    fn from(v: Kilo) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl From<Mega> for MinBytesForConcurrentDownload {
+    fn from(v: Mega) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl From<Giga> for MinBytesForConcurrentDownload {
+    fn from(v: Giga) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl From<Kibi> for MinBytesForConcurrentDownload {
+    fn from(v: Kibi) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl From<Mebi> for MinBytesForConcurrentDownload {
+    fn from(v: Mebi) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl From<Gibi> for MinBytesForConcurrentDownload {
+    fn from(v: Gibi) -> Self {
+        MinBytesForConcurrentDownload::new(v)
+    }
+}
+
+impl FromStr for MinBytesForConcurrentDownload {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_dimension(s).map(MinBytesForConcurrentDownload)
+    }
+}
+
+new_type! {
     #[doc="Behaviour for get size requests"]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub copy struct AlwaysGetSize(bool, env="ALWAYS_GET_SIZE");
@@ -394,6 +654,34 @@ impl Default for MaxBuffersFullDelayMs {
 impl From<MaxBuffersFullDelayMs> for Duration {
     fn from(m: MaxBuffersFullDelayMs) -> Self {
         Duration::from_millis(m.0)
+    }
+}
+
+new_type! {
+    #[doc="If set to `true` download related messages are logged at `DEBUG` level. Otherwise at `INFO` level."]
+    #[doc="The default is `true` (log on `DEBUG` level)."]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub copy struct LogDownloadMessagesAsDebug(bool, env="LOG_DOWNLOAD_MESSAGES_AS_DEBUG");
+}
+
+impl LogDownloadMessagesAsDebug {
+    pub(crate) fn log<T: AsRef<str>>(self, msg: T) {
+        if *self {
+            debug!("{}", msg.as_ref());
+        } else {
+            info!("{}", msg.as_ref());
+        }
+    }
+
+    /// Returns the inner value
+    pub fn value(self) -> bool {
+        self.0
+    }
+}
+
+impl Default for LogDownloadMessagesAsDebug {
+    fn default() -> Self {
+        LogDownloadMessagesAsDebug(true)
     }
 }
 

--- a/condow_core/src/config.rs
+++ b/condow_core/src/config.rs
@@ -719,7 +719,7 @@ pub enum SequentialDownloadMode {
     /// have to be made.
     ///
     /// This is the default
-    SingleDownload,
+    MergeParts,
     /// Repartition the download into parts with
     /// mostly the given size
     Repartition { part_size: PartSizeBytes },
@@ -735,7 +735,7 @@ impl SequentialDownloadMode {
 
 impl Default for SequentialDownloadMode {
     fn default() -> Self {
-        Self::SingleDownload
+        Self::MergeParts
     }
 }
 
@@ -752,7 +752,7 @@ impl FromStr for SequentialDownloadMode {
         let s = s.trim();
         match s {
             "KEEP_PARTS" => Ok(Self::KeepParts),
-            "SINGLE_DOWNLOAD" => Ok(Self::SingleDownload),
+            "SINGLE_DOWNLOAD" => Ok(Self::MergeParts),
             probably_a_number => {
                 let part_size = probably_a_number.parse()?;
                 Ok(Self::Repartition { part_size })
@@ -1043,12 +1043,12 @@ impl FromStr for UnitPrefix {
                 s => bail!("invalid unit: '{}'", s),
             }
         } else {
-            Ok(s.parse::<u64>().map( UnitPrefix::Unit)?)
+            Ok(s.parse::<u64>().map(UnitPrefix::Unit)?)
         }
     }
 }
 
-impl PartialEq for UnitPrefix  {
+impl PartialEq for UnitPrefix {
     fn eq(&self, other: &Self) -> bool {
         self.value() == other.value()
     }

--- a/condow_core/src/download_range.rs
+++ b/condow_core/src/download_range.rs
@@ -270,8 +270,8 @@ impl ClosedRange {
         }
     }
 
-    pub fn len(&self) -> u64 {
-        match *self {
+    pub fn len(self) -> u64 {
+        match self {
             Self::FromTo(a, b) => b - a,
             Self::FromToInclusive(a, b) => b - a + 1,
             Self::To(last_excl) => last_excl,
@@ -516,6 +516,14 @@ impl DownloadRange {
         match self {
             DownloadRange::Open(r) => r.incl_range_from_size(size),
             DownloadRange::Closed(r) => r.incl_range_from_size(size),
+        }
+    }
+
+    /// Returns the length in bytes for ranges where an end is defined
+    pub fn len(self) -> Option<u64> {
+        match self {
+            DownloadRange::Open(_) => None,
+            DownloadRange::Closed(r) => Some(r.len()),
         }
     }
 }

--- a/condow_core/src/helpers.rs
+++ b/condow_core/src/helpers.rs
@@ -200,8 +200,23 @@ macro_rules! __new_type_base {
 macro_rules! __new_type_base_copy_ext {
     ($Name:ident; $T:ty) => {
         impl $Name {
+            /// Returns the inner representation
             pub fn into_inner(self) -> $T {
                 self.0
+            }
+        }
+
+        impl std::ops::Deref for $Name {
+            type Target = $T;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $Name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
             }
         }
     };

--- a/condow_core/src/machinery/download/concurrent/mod.rs
+++ b/condow_core/src/machinery/download/concurrent/mod.rs
@@ -51,7 +51,7 @@ pub(crate) struct ConcurrentDownloader<P: Probe + Clone> {
     downloaders: Vec<SequentialDownloader>,
     counter: usize,
     kill_switch: KillSwitch,
-    config: Config,
+    config: Arc<Config>,
     probe: P,
 }
 
@@ -68,6 +68,7 @@ impl<P: Probe + Clone> ConcurrentDownloader<P> {
         let started_at = Instant::now();
         let kill_switch = KillSwitch::new();
         let counter = Arc::new(AtomicUsize::new(0));
+        let config = Arc::new(config.clone());
         let downloaders: Vec<_> = (0..n_concurrent)
             .map(|_| {
                 SequentialDownloader::new(
@@ -81,6 +82,7 @@ impl<P: Probe + Clone> ConcurrentDownloader<P> {
                         probe.clone(),
                         started_at,
                         download_span_guard.clone(),
+                        Arc::clone(&config),
                     ),
                 )
             })

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -51,9 +51,14 @@ pub(crate) async fn download_chunks_sequentially<C: CondowClient, P: Probe + Clo
     client: ClientRetryWrapper<C>,
     location: C::Location,
     probe: P,
+    config: Config,
 ) -> Result<ChunkStream, CondowError> {
-    Ok(
-        self::sequential::download_chunks_sequentially(part_requests, client, location, probe)
-            .await,
+    Ok(self::sequential::download_chunks_sequentially(
+        part_requests,
+        client,
+        location,
+        probe,
+        config,
     )
+    .await)
 }

--- a/condow_core/src/machinery/part_request.rs
+++ b/condow_core/src/machinery/part_request.rs
@@ -5,7 +5,7 @@ use crate::{streams::BytesHint, InclusiveRange};
 /// A request to download a part.
 ///
 /// This is a part a download is split into.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PartRequest {
     /// Index of the part
     pub part_index: u64,
@@ -64,6 +64,19 @@ impl PartRequestIterator {
     /// Turns this iterator into a [Stream]
     pub fn into_stream(self) -> impl Stream<Item = PartRequest> {
         futures::stream::iter(self)
+    }
+
+    #[cfg(test)]
+    pub fn clone_continue(&self) -> Self {
+        Self {
+            start: self.start,
+            part_size: self.part_size,
+            next_range_offset: self.next_range_offset,
+            next_part_index: self.next_part_index,
+            parts_left: self.parts_left,
+            end_incl: self.end_incl,
+            bytes_left: self.bytes_left,
+        }
     }
 }
 

--- a/condow_core/src/machinery/tests.rs
+++ b/condow_core/src/machinery/tests.rs
@@ -214,7 +214,7 @@ mod download_chunks {
     use crate::{
         condow_client::IgnoreLocation,
         config::Config,
-        machinery::{download_chunks, DownloadSpanGuard},
+        machinery::{download_chunks, part_request::PartRequestIterator, DownloadSpanGuard},
         streams::BytesHint,
         test_utils::*,
         InclusiveRange,
@@ -234,11 +234,12 @@ mod download_chunks {
 
         let range = InclusiveRange(0, 8);
         let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+        let part_requests = PartRequestIterator::new(range, 100);
 
         let result_stream = download_chunks(
             client.into(),
             IgnoreLocation,
-            range,
+            part_requests,
             bytes_hint,
             config,
             (),
@@ -253,7 +254,7 @@ mod download_chunks {
     }
 
     #[tokio::test]
-    async fn from_0_to_inclusive_range_equal_size_than_part_size() {
+    async fn from_0_to_inclusive_range_equal_size_as_part_size() {
         let buffer_size = 10;
         let client = TestCondowClient::new().max_chunk_size(3);
         let data = client.data();
@@ -266,11 +267,12 @@ mod download_chunks {
 
         let range = InclusiveRange(0, 9);
         let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+        let part_requests = PartRequestIterator::new(range, range.len());
 
         let result_stream = download_chunks(
             client.into(),
             IgnoreLocation,
-            range,
+            part_requests,
             bytes_hint,
             config,
             (),
@@ -298,11 +300,12 @@ mod download_chunks {
 
         let range = InclusiveRange(0, 10);
         let bytes_hint = BytesHint::new(range.len(), Some(range.len()));
+        let part_requests = PartRequestIterator::new(range, 3);
 
         let result_stream = download_chunks(
             client.into(),
             IgnoreLocation,
-            range,
+            part_requests,
             bytes_hint,
             config,
             (),

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -215,7 +215,7 @@ impl<L> Request<L> {
         self.params
             .config
             .validate()
-            .map_err(|err| CondowError::new_other("invalid configurant").with_source(err))?;
+            .map_err(|err| CondowError::new_other("invalid configuration").with_source(err))?;
         (self.download_fn)(self.location, self.params).await
     }
 

--- a/condow_core/src/request.rs
+++ b/condow_core/src/request.rs
@@ -212,6 +212,10 @@ impl<L> Request<L> {
 
     /// Download as a [ChunkStream]
     pub async fn download_chunks(self) -> Result<ChunkStream, CondowError> {
+        self.params
+            .config
+            .validate()
+            .map_err(|err| CondowError::new_other("invalid configurant").with_source(err))?;
         (self.download_fn)(self.location, self.params).await
     }
 


### PR DESCRIPTION
Make sequential downloads more configurable:

- config parameter `LogDownloadMessagesAsDebug` to configure log level of outer doenload events
- config parameters `MinPartsForConcurrentDownload`, `MinBytesForConcurrentDownload` and `SequentialDownloadMode` to configure sequential downloads

closes #61 