### PR TITLE
A lot of clippy fixes

### DIFF
--- a/condow_core/src/condow_client.rs
+++ b/condow_core/src/condow_client.rs
@@ -213,7 +213,7 @@ mod in_memory {
         ) -> BoxFuture<'static, Result<(BytesStream, BytesHint), CondowError>> {
             trace!("in-memory-client: download");
 
-            download(&self.blob.as_slice(), self.chunk_size, spec)
+            download(self.blob.as_slice(), self.chunk_size, spec)
         }
     }
 
@@ -272,7 +272,7 @@ mod in_memory {
         pub fn as_slice(&self) -> &[u8] {
             match self {
                 Blob::Static(b) => b,
-                Blob::Owned(b) => &b,
+                Blob::Owned(b) => b,
             }
         }
     }
@@ -626,7 +626,7 @@ pub mod failing_client_simulator {
         pub fn as_slice(&self) -> &[u8] {
             match self {
                 Blob::Static(b) => b,
-                Blob::Owned(b) => &b,
+                Blob::Owned(b) => b,
             }
         }
     }

--- a/condow_core/src/config.rs
+++ b/condow_core/src/config.rs
@@ -513,14 +513,8 @@ new_type! {
     #[doc="This is not always the case since some low concurrency downloads require the strem to be actively pulled."]
     #[doc="This also allows for detection of panics."]
     #[doc="The default is `false` which means this feature is turned off."]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub copy struct EnsureActivePull(bool, env="ENSURE_ACTIVE_PULL");
-}
-
-impl Default for EnsureActivePull {
-    fn default() -> Self {
-        EnsureActivePull(false)
-    }
 }
 
 new_type! {
@@ -1011,6 +1005,8 @@ impl From<Gibi> for u64 {
 /// ```
 #[derive(Debug, Clone, Copy, Eq, Ord)]
 pub enum UnitPrefix {
+    // FIXME: Ord above is derived, while OrdPartial is not
+    // see https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord
     Unit(u64),
     Kilo(u64),
     Mega(u64),

--- a/condow_core/src/download_range.rs
+++ b/condow_core/src/download_range.rs
@@ -270,6 +270,10 @@ impl ClosedRange {
         }
     }
 
+    pub fn is_empty(self) -> bool {
+        self.len() == 0 // is this efficient enough?
+    }
+
     pub fn len(self) -> u64 {
         match self {
             Self::FromTo(a, b) => b - a,
@@ -520,7 +524,7 @@ impl DownloadRange {
     }
 
     /// Returns the length in bytes for ranges where an end is defined
-    pub fn len(self) -> Option<u64> {
+    pub fn len(&self) -> Option<u64> {
         match self {
             DownloadRange::Open(_) => None,
             DownloadRange::Closed(r) => Some(r.len()),

--- a/condow_core/src/lib.rs
+++ b/condow_core/src/lib.rs
@@ -141,16 +141,13 @@ pub trait Downloads: Send + Sync + 'static {
     fn blob(&self) -> RequestNoLocation<Self::Location>;
 
     /// Get the size of a BLOB at the given location
-    fn get_size<'a>(&'a self, location: Self::Location) -> BoxFuture<'a, Result<u64, CondowError>>;
+    fn get_size(&self, location: Self::Location) -> BoxFuture<Result<u64, CondowError>>;
 
     /// Creates a [RandomAccessReader] for the given location
     ///
     /// This function will query the size of the BLOB. If the size is already known
     /// call [Downloads::reader_with_length]
-    fn reader<'a>(
-        &'a self,
-        location: Self::Location,
-    ) -> BoxFuture<'a, Result<RandomAccessReader, CondowError>>
+    fn reader(&self, location: Self::Location) -> BoxFuture<Result<RandomAccessReader, CondowError>>
     where
         Self: Sized + Sync,
     {
@@ -394,7 +391,7 @@ where
         self.blob()
     }
 
-    fn get_size<'a>(&'a self, location: Self::Location) -> BoxFuture<'a, Result<u64, CondowError>> {
+    fn get_size(&self, location: Self::Location) -> BoxFuture<Result<u64, CondowError>> {
         Box::pin(self.get_size(location))
     }
 

--- a/condow_core/src/machinery/download/concurrent/four_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/four_concurrently.rs
@@ -242,7 +242,7 @@ impl<P: Probe + Clone> Stream for FourPartsConcurrently<P> {
     ) -> std::task::Poll<Option<Self::Item>> {
         use Poll::*;
 
-        let mut this = self.project();
+        let this = self.project();
 
         // We need to get ownership of the state. So we have to reassign it in each match
         // arm unless we want to be in "Finished" state.
@@ -257,7 +257,7 @@ impl<P: Probe + Clone> Stream for FourPartsConcurrently<P> {
                 right,
             } => {
                 let (poll_result, next_state) =
-                    match poll_four(left, mid_left, mid_right, right, &mut this.baggage, cx) {
+                    match poll_four(left, mid_left, mid_right, right, this.baggage, cx) {
                         Ok(ok) => ok,
                         Err(err) => {
                             this.baggage

--- a/condow_core/src/machinery/download/concurrent/parallel/mod.rs
+++ b/condow_core/src/machinery/download/concurrent/parallel/mod.rs
@@ -44,7 +44,7 @@ impl<P: Probe + Clone> ParallelDownloader<P> {
         let started_at = Instant::now();
         let kill_switch = KillSwitch::new();
         let counter = Arc::new(AtomicUsize::new(0));
-        let config = Arc::new(config.clone());
+        let config = Arc::new(config);
         let downloaders: Vec<_> = (0..*config.max_concurrency)
             .map(|_| {
                 SequentialDownloader::new(

--- a/condow_core/src/machinery/download/concurrent/parallel/worker.rs
+++ b/condow_core/src/machinery/download/concurrent/parallel/worker.rs
@@ -31,7 +31,7 @@ use super::KillSwitch;
 /// Results are pushed into a channel via the [DownloaderContext].
 ///
 /// Usually one `SequentialDownloader` is created for each level of
-/// concurrency.  
+/// concurrency.
 pub(crate) struct SequentialDownloader {
     request_sender: Sender<PartRequest>,
 }
@@ -52,7 +52,7 @@ impl SequentialDownloader {
                 let mut request_receiver = Box::pin(request_receiver);
                 while let Some(range_request) = request_receiver.recv().await {
                     let span = debug_span!(
-                        parent: context.span(), "download_part", 
+                        parent: context.span(), "download_part",
                         part_index = %range_request.part_index,
                         part_range = %range_request.blob_range,
                         part_offset = %range_request.range_offset);
@@ -161,7 +161,7 @@ impl<P: Probe + Clone> DownloaderContext<P> {
 
         self.kill_switch.push_the_button();
 
-        return Err(());
+        Err(())
     }
 
     /// Send an error and mark as completed

--- a/condow_core/src/machinery/download/concurrent/three_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/three_concurrently.rs
@@ -202,7 +202,7 @@ impl<P: Probe + Clone> Stream for ThreePartsConcurrently<P> {
     ) -> std::task::Poll<Option<Self::Item>> {
         use Poll::*;
 
-        let mut this = self.project();
+        let this = self.project();
 
         // We need to get ownership of the state. So we have to reassign it in each match
         // arm unless we want to be in "Finished" state.
@@ -216,7 +216,7 @@ impl<P: Probe + Clone> Stream for ThreePartsConcurrently<P> {
                 right,
             } => {
                 let (poll_result, next_state) =
-                    match poll_three(left, middle, right, &mut this.baggage, cx) {
+                    match poll_three(left, middle, right, this.baggage, cx) {
                         Ok(ok) => ok,
                         Err(err) => {
                             this.baggage

--- a/condow_core/src/machinery/download/concurrent/two_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/two_concurrently.rs
@@ -166,7 +166,7 @@ impl<P: Probe + Clone> Stream for TwoPartsConcurrently<P> {
     ) -> std::task::Poll<Option<Self::Item>> {
         use Poll::*;
 
-        let mut this = self.project();
+        let this = self.project();
 
         // We need to get ownership of the state. So we have to reassign it in each match
         // arm unless we want to be in "Finished" state.
@@ -199,7 +199,7 @@ impl<P: Probe + Clone> Stream for TwoPartsConcurrently<P> {
                 }
             },
             ActiveStreams::TwoConcurrently { left, right } => {
-                let (poll_result, next_state) = match poll_two(left, right, &mut this.baggage, cx) {
+                let (poll_result, next_state) = match poll_two(left, right, this.baggage, cx) {
                     Ok(ok) => ok,
                     Err(err) => {
                         this.baggage

--- a/condow_core/src/machinery/download/sequential/mod.rs
+++ b/condow_core/src/machinery/download/sequential/mod.rs
@@ -186,7 +186,7 @@ where
                         Poll::Ready(Some(Ok(chunk)))
                     }
                     Poll::Ready(Some(Err(err))) => {
-                        let err: CondowError = err.into();
+                        let err: CondowError = err;
                         this.probe
                             .download_failed(Some(this.download_started_at.elapsed()));
                         this.log_dl_msg_dbg.log(format!("download failed: {err}"));

--- a/condow_core/src/probe.rs
+++ b/condow_core/src/probe.rs
@@ -213,7 +213,7 @@ impl ProbeFactory for () {
     type Probe = ();
 
     fn make(&self, _location: &dyn fmt::Display) -> Self::Probe {
-        ()
+        // noop
     }
 }
 

--- a/condow_core/src/reader/bytes_async_reader.rs
+++ b/condow_core/src/reader/bytes_async_reader.rs
@@ -33,7 +33,7 @@ where
         cx: &mut task::Context<'_>,
         dest_buf: &mut [u8],
     ) -> task::Poll<IoResult<usize>> {
-        if dest_buf.len() == 0 {
+        if dest_buf.is_empty() {
             return task::Poll::Ready(Ok(0));
         }
 

--- a/condow_core/src/retry/tests.rs
+++ b/condow_core/src/retry/tests.rs
@@ -668,11 +668,11 @@ mod retry_download {
             }
         }
 
-        return Ok((
+        Ok((
             probe.0.load(Ordering::SeqCst),
             probe.1.load(Ordering::SeqCst),
             Ok(received),
-        ));
+        ))
     }
 }
 
@@ -1192,6 +1192,7 @@ mod retry_download_get_stream {
         for kind in ERROR_KINDS {
             let errors = vec![kind; n_errors];
             let result = run_get_stream(errors, n_retries).await;
+            // FIXME: if statement has identical if and else
             let expected = if kind.is_retryable() {
                 Err((0, kind))
             } else {
@@ -1437,6 +1438,7 @@ mod retry_get_size {
         for kind in ERROR_KINDS {
             let errors = vec![kind; n_errors];
             let result = run_get_size(errors, n_retries).await;
+            // FIXME: if statement has identical if and else
             let expected = if kind.is_retryable() {
                 Err((0, kind))
             } else {

--- a/condow_core/src/streams/ordered_chunk_stream.rs
+++ b/condow_core/src/streams/ordered_chunk_stream.rs
@@ -249,6 +249,7 @@ impl Stream for OrderedChunkStream {
 const MAX_BUFFER_RESERVOIR_SIZE: usize = 128;
 const INITIAL_BUFFER_CAPACITY: usize = 32;
 
+#[derive(Default)]
 struct BufferReservoir {
     queues: Vec<VecDeque<Chunk>>,
 }
@@ -268,12 +269,6 @@ impl BufferReservoir {
         if self.queues.len() < MAX_BUFFER_RESERVOIR_SIZE {
             self.queues.push(queue)
         }
-    }
-}
-
-impl Default for BufferReservoir {
-    fn default() -> Self {
-        Self { queues: Vec::new() }
     }
 }
 


### PR DESCRIPTION
I ran `cargo clippy` on the code, fixing the most glaring issues, while commenting on a few more. I think `cargo clippy` should be added to the CI to avoid these issues in the future.

One "significant" change I made was to change `download_range` to use a borrow instead of the object itself. I don't see why the object should be consumed if you only want to get its length.

Please run `cargo clippy` to see other issues