### PR TITLE
Reduce dynamic dispatch on streams

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-condow_core = { version = "0.18", path = "../condow_core"}
+condow_core = { version = "0.19.0-alpha.1", path = "../condow_core"}
 
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time", "rt-multi-thread"] }

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -6,10 +6,9 @@ use bytes::Bytes;
 use futures::{future::BoxFuture, stream, FutureExt, StreamExt};
 
 use condow_core::{
-    condow_client::{CondowClient, IgnoreLocation},
+    condow_client::{ClientBytesStream, CondowClient, IgnoreLocation},
     config::Config,
     errors::CondowError,
-    streams::{BytesHint, BytesStream},
     Condow, InclusiveRange,
 };
 
@@ -48,7 +47,7 @@ impl CondowClient for BenchmarkClient {
         &self,
         _location: Self::Location,
         range: InclusiveRange,
-    ) -> BoxFuture<'static, Result<BytesStream, CondowError>> {
+    ) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>> {
         let bytes_to_send = {
             if range.end_incl() >= self.size {
                 return futures::future::err(CondowError::new_other("out of range")).boxed();
@@ -88,7 +87,7 @@ impl CondowClient for BenchmarkClient {
             chunk
         });
         //       let stream = stream::iter(iter);
-        let stream = BytesStream::new(stream, BytesHint::new_exact(bytes_to_send));
+        let stream = ClientBytesStream::new(stream, bytes_to_send);
 
         futures::future::ok(stream).boxed()
     }

--- a/condow_core/CHANGELOG.md
+++ b/condow_core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.0-alpha.1 - 2022-06-09
+
+### CHANGED
+
+- Internally no dyn dispatch streams (except from client)
+- No more notification on individual chunks received
+
 ## 0.18.2 - 2022-06-07
 
 ### ADDED

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -16,6 +16,7 @@ pin-project-lite = "0.2"
 bytes = "1"
 futures = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
+tokio-stream = "0.1.9"
 thiserror = "1.0"
 anyhow = "1.0"
 tracing = "0.1"

--- a/condow_core/Cargo.toml
+++ b/condow_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_core"
-version = "0.18.2"
+version = "0.19.0-alpha.1"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"

--- a/condow_core/src/condow/tests.rs
+++ b/condow_core/src/condow/tests.rs
@@ -97,7 +97,6 @@ mod range {
                 let client = TestCondowClient {
                     data: Arc::clone(&data),
                     max_jitter_ms: 0,
-                    include_size_hint: true,
                     max_chunk_size: chunk_size,
                     ..TestCondowClient::default()
                 };
@@ -146,7 +145,6 @@ mod range {
                 let client = TestCondowClient {
                     data: Arc::clone(&data),
                     max_jitter_ms: 0,
-                    include_size_hint: true,
                     max_chunk_size: chunk_size,
                     ..TestCondowClient::default()
                 };
@@ -197,7 +195,6 @@ mod range {
                 let client = TestCondowClient {
                     data: Arc::clone(&data),
                     max_jitter_ms: 0,
-                    include_size_hint: true,
                     max_chunk_size: chunk_size,
                     ..TestCondowClient::default()
                 };
@@ -256,7 +253,6 @@ mod range {
                         let client = TestCondowClient {
                             data: Arc::clone(&data),
                             max_jitter_ms: 0,
-                            include_size_hint: true,
                             max_chunk_size: chunk_size,
                             ..TestCondowClient::default()
                         };
@@ -308,7 +304,6 @@ mod range {
                         let client = TestCondowClient {
                             data: Arc::clone(&data),
                             max_jitter_ms: 0,
-                            include_size_hint: true,
                             max_chunk_size: chunk_size,
                             ..TestCondowClient::default()
                         };
@@ -367,7 +362,6 @@ mod range {
                         let client = TestCondowClient {
                             data: Arc::clone(&data),
                             max_jitter_ms: 0,
-                            include_size_hint: true,
                             max_chunk_size: chunk_size,
                             ..TestCondowClient::default()
                         };
@@ -425,7 +419,6 @@ mod range {
                         let client = TestCondowClient {
                             data: Arc::clone(&data),
                             max_jitter_ms: 0,
-                            include_size_hint: true,
                             max_chunk_size: chunk_size,
                             ..TestCondowClient::default()
                         };

--- a/condow_core/src/condow_client.rs
+++ b/condow_core/src/condow_client.rs
@@ -21,6 +21,9 @@ pub use in_memory::InMemoryClient;
 ///
 /// Implementors of this trait may not panic on calling any of the methods nor
 /// within any of the futures returned.
+///
+/// It is suggested that `FromStr` is implemented for `Location` as well as a [From] implentation
+/// for [IgnoreLocation].
 pub trait CondowClient: Clone + Send + Sync + 'static {
     type Location: std::fmt::Debug + std::fmt::Display + Clone + Send + Sync + 'static;
 
@@ -93,6 +96,13 @@ mod client_bytes_stream {
     use crate::streams::{BytesHint, BytesStreamItem};
 
     pin_project! {
+    /// A stream of [Bytes] (chunks) where there can be an error for each chunk of bytes.
+    ///
+    /// Implementors of [CondowClient] return this stream.
+    ///
+    /// This stream is NOT fused and depends on the input stream.
+    ///
+    /// [CondowClient]:crate::condow_client::CondowClient
     pub struct ClientBytesStream {
         #[pin]
         source: SourceFlavour,
@@ -144,6 +154,7 @@ mod client_bytes_stream {
                 exact_bytes_left,
             }
         }
+
         pub fn new_tokio_receiver(
             receiver: tokio_mpsc::UnboundedReceiver<BytesStreamItem>,
             exact_bytes_left: u64,

--- a/condow_core/src/machinery/configure_download.rs
+++ b/condow_core/src/machinery/configure_download.rs
@@ -25,8 +25,8 @@ impl<L> DownloadConfiguration<L> {
     }
 
     /// Retrns a hint on the amount of bytes returned from this stream
-    pub fn bytes_hint(&self) -> BytesHint {
-        self.part_requests.bytes_hint()
+    pub fn exact_bytes(&self) -> u64 {
+        self.part_requests.exact_bytes_left()
     }
 }
 

--- a/condow_core/src/machinery/configure_download.rs
+++ b/condow_core/src/machinery/configure_download.rs
@@ -6,7 +6,6 @@ use crate::{
     errors::CondowError,
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::BytesHint,
     DownloadRange, InclusiveRange,
 };
 

--- a/condow_core/src/machinery/download/concurrent/four_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/four_concurrently.rs
@@ -1,5 +1,6 @@
 //! Download with a maximum concurrncy of 3
 use std::{
+    sync::Arc,
     task::Poll,
     time::{Duration, Instant},
 };
@@ -27,55 +28,55 @@ pin_project! {
     /// parts which have a lower part number (they come in ordered).
     ///
     /// This way there is less entropy in the ordering of the returned chunks.
-    pub struct FourPartsConcurrently<P: Probe> {
-        active_streams: ActiveStreams<P>,
-        baggage: Baggage<P>,
+    pub struct FourPartsConcurrently {
+        active_streams: ActiveStreams,
+        baggage: Baggage,
    }
 }
 
-struct Baggage<P: Probe> {
+struct Baggage {
     get_part_stream: Box<
         dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
             + Send
             + 'static,
     >,
     part_requests: Box<dyn Iterator<Item = PartRequest> + Send + 'static>,
-    probe: P,
+    probe: Arc<dyn Probe>,
     download_started_at: Instant,
     log_dl_msg_dbg: LogDownloadMessagesAsDebug,
     download_span_guard: DownloadSpanGuard,
 }
 
-enum ActiveStreams<P: Probe> {
+enum ActiveStreams {
     /// Nothing more to do
     None,
     /// There are 4 or more parts left to download
     FourConcurrently {
-        left: PartChunksStream<P>,
-        mid_left: PartChunksStream<P>,
-        mid_right: PartChunksStream<P>,
-        right: PartChunksStream<P>,
+        left: PartChunksStream,
+        mid_left: PartChunksStream,
+        mid_right: PartChunksStream,
+        right: PartChunksStream,
     },
     /// There are exactly 3 left to download
     LastThreeConcurrently {
-        left: PartChunksStream<P>,
-        middle: PartChunksStream<P>,
-        right: PartChunksStream<P>,
+        left: PartChunksStream,
+        middle: PartChunksStream,
+        right: PartChunksStream,
     },
     /// There are exactly 2 parts left to download
     LastTwoConcurrently {
-        left: PartChunksStream<P>,
-        right: PartChunksStream<P>,
+        left: PartChunksStream,
+        right: PartChunksStream,
     },
     /// There is exactly 1 part left to download
-    LastPart(PartChunksStream<P>),
+    LastPart(PartChunksStream),
 }
 
-impl<P: Probe + Clone> FourPartsConcurrently<P> {
+impl FourPartsConcurrently {
     pub(crate) fn new<I, L, F>(
         get_part_stream: F,
         mut part_requests: I,
-        probe: P,
+        probe: Arc<dyn Probe>,
         log_dl_msg_dbg: L,
         download_span_guard: DownloadSpanGuard,
     ) -> Self
@@ -199,7 +200,7 @@ impl<P: Probe + Clone> FourPartsConcurrently<P> {
         }
     }
 
-    pub(crate) fn from_client<C, I, L>(
+    pub(crate) fn from_client<C, I, L, P>(
         client: ClientRetryWrapper<C>,
         location: C::Location,
         part_requests: I,
@@ -211,6 +212,7 @@ impl<P: Probe + Clone> FourPartsConcurrently<P> {
         I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
         C: CondowClient,
+        P: Probe + Clone,
     {
         let get_part_stream = {
             let probe = probe.clone();
@@ -224,14 +226,14 @@ impl<P: Probe + Clone> FourPartsConcurrently<P> {
         Self::new(
             get_part_stream,
             part_requests,
-            probe,
+            Arc::new(probe),
             log_dl_msg_dbg,
             download_span_guard,
         )
     }
 }
 
-impl<P: Probe + Clone> Stream for FourPartsConcurrently<P> {
+impl Stream for FourPartsConcurrently {
     type Item = ChunkStreamItem;
 
     fn poll_next(
@@ -341,14 +343,14 @@ impl<P: Probe + Clone> Stream for FourPartsConcurrently<P> {
 ///
 /// Add new parts to the right. If the right slot is not free
 /// move items to the left before adding the new part.
-fn poll_four<P: Probe + Clone>(
-    mut left: PartChunksStream<P>,
-    mut mid_left: PartChunksStream<P>,
-    mut mid_right: PartChunksStream<P>,
-    mut right: PartChunksStream<P>,
-    baggage: &mut Baggage<P>,
+fn poll_four(
+    mut left: PartChunksStream,
+    mut mid_left: PartChunksStream,
+    mut mid_right: PartChunksStream,
+    mut right: PartChunksStream,
+    baggage: &mut Baggage,
     cx: &mut std::task::Context<'_>,
-) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams<P>), CondowError> {
+) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams), CondowError> {
     match left.poll_next_unpin(cx) {
         Poll::Ready(Some(Ok(chunk))) => {
             return Ok((
@@ -542,12 +544,12 @@ fn poll_four<P: Probe + Clone>(
 ///
 /// Add new parts to the right. If the right slot is not free
 /// move items to the left before adding the new part.
-fn poll_last_three<P: Probe + Clone>(
-    mut left: PartChunksStream<P>,
-    mut middle: PartChunksStream<P>,
-    mut right: PartChunksStream<P>,
+fn poll_last_three(
+    mut left: PartChunksStream,
+    mut middle: PartChunksStream,
+    mut right: PartChunksStream,
     cx: &mut std::task::Context<'_>,
-) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams<P>), CondowError> {
+) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams), CondowError> {
     match left.poll_next_unpin(cx) {
         Poll::Ready(Some(Ok(chunk))) => {
             return Ok((
@@ -629,11 +631,11 @@ fn poll_last_three<P: Probe + Clone>(
 /// poll "left biased" until there is only 1 part left
 ///
 /// There are exactly 2 parts left to download.
-fn poll_last_two<P: Probe + Clone>(
-    mut left: PartChunksStream<P>,
-    mut right: PartChunksStream<P>,
+fn poll_last_two(
+    mut left: PartChunksStream,
+    mut right: PartChunksStream,
     cx: &mut std::task::Context<'_>,
-) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams<P>), CondowError> {
+) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams), CondowError> {
     match left.poll_next_unpin(cx) {
         Poll::Ready(Some(Ok(chunk))) => {
             return Ok((

--- a/condow_core/src/machinery/download/concurrent/four_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/four_concurrently.rs
@@ -9,13 +9,13 @@ use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use pin_project_lite::pin_project;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     config::LogDownloadMessagesAsDebug,
     errors::CondowError,
     machinery::{download::PartChunksStream, part_request::PartRequest, DownloadSpanGuard},
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::{BytesStream, ChunkStreamItem},
+    streams::ChunkStreamItem,
     InclusiveRange,
 };
 
@@ -36,7 +36,7 @@ pin_project! {
 
 struct Baggage {
     get_part_stream: Box<
-        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     >,
@@ -83,7 +83,7 @@ impl FourPartsConcurrently {
     where
         I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
-        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     {

--- a/condow_core/src/machinery/download/concurrent/mod.rs
+++ b/condow_core/src/machinery/download/concurrent/mod.rs
@@ -128,7 +128,7 @@ fn download_chunks_two_concurrently<C: CondowClient, P: Probe + Clone>(
 
     if *config.ensure_active_pull {
         let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
-        ChunkStream::from_receiver(active_stream, bytes_hint)
+        ChunkStream::from_active_stream(active_stream, bytes_hint)
     } else {
         ChunkStream::from_two_concurrently(stream, bytes_hint)
     }
@@ -163,7 +163,7 @@ fn download_chunks_three_concurrently<C: CondowClient, P: Probe + Clone>(
 
     if *config.ensure_active_pull {
         let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
-        ChunkStream::from_receiver(active_stream, bytes_hint)
+        ChunkStream::from_active_stream(active_stream, bytes_hint)
     } else {
         ChunkStream::from_three_concurrently(stream, bytes_hint)
     }
@@ -198,7 +198,7 @@ fn download_chunks_four_concurrently<C: CondowClient, P: Probe + Clone>(
 
     if *config.ensure_active_pull {
         let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
-        ChunkStream::from_receiver(active_stream, bytes_hint)
+        ChunkStream::from_active_stream(active_stream, bytes_hint)
     } else {
         ChunkStream::from_four_concurrently(stream, bytes_hint)
     }

--- a/condow_core/src/machinery/download/concurrent/mod.rs
+++ b/condow_core/src/machinery/download/concurrent/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     config::ClientRetryWrapper,
     machinery::{configure_download::DownloadConfiguration, DownloadSpanGuard},
     probe::Probe,
-    streams::{BytesStream, ChunkStream},
+    streams::{BytesHint, BytesStream, ChunkStream},
 };
 
 use self::parallel::ParallelDownloader;
@@ -18,6 +18,10 @@ mod four_concurrently;
 mod parallel;
 mod three_concurrently;
 mod two_concurrently;
+
+pub use four_concurrently::FourPartsConcurrently;
+pub use three_concurrently::ThreePartsConcurrently;
+pub use two_concurrently::TwoPartsConcurrently;
 
 /// Download the chunks concurrently
 ///
@@ -72,7 +76,7 @@ fn download_chunks_parallel<C: CondowClient, P: Probe + Clone>(
     probe: P,
     download_span_guard: DownloadSpanGuard,
 ) -> ChunkStream {
-    let bytes_hint = configuration.bytes_hint();
+    let bytes_hint = BytesHint::new_exact(configuration.exact_bytes());
 
     let DownloadConfiguration {
         location,
@@ -104,7 +108,7 @@ fn download_chunks_two_concurrently<C: CondowClient, P: Probe + Clone>(
     probe: P,
     download_span_guard: DownloadSpanGuard,
 ) -> ChunkStream {
-    let bytes_hint = configuration.bytes_hint();
+    let bytes_hint = BytesHint::new_exact(configuration.exact_bytes());
 
     let DownloadConfiguration {
         location,
@@ -115,7 +119,7 @@ fn download_chunks_two_concurrently<C: CondowClient, P: Probe + Clone>(
 
     let log_dl_msg_as_dbg = config.log_download_messages_as_debug;
 
-    let downloader = two_concurrently::TwoPartsConcurrently::from_client(
+    let stream = two_concurrently::TwoPartsConcurrently::from_client(
         client,
         location,
         part_requests,
@@ -125,10 +129,10 @@ fn download_chunks_two_concurrently<C: CondowClient, P: Probe + Clone>(
     );
 
     if *config.ensure_active_pull {
-        let active_stream = active_pull(downloader, probe, log_dl_msg_as_dbg);
+        let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
         ChunkStream::from_receiver(active_stream, bytes_hint)
     } else {
-        ChunkStream::from_stream(downloader.boxed(), bytes_hint)
+        ChunkStream::from_two_concurrently(stream, bytes_hint)
     }
 }
 
@@ -139,7 +143,7 @@ fn download_chunks_three_concurrently<C: CondowClient, P: Probe + Clone>(
     probe: P,
     download_span_guard: DownloadSpanGuard,
 ) -> ChunkStream {
-    let bytes_hint = configuration.bytes_hint();
+    let bytes_hint = BytesHint::new_exact(configuration.exact_bytes());
 
     let DownloadConfiguration {
         location,
@@ -150,7 +154,7 @@ fn download_chunks_three_concurrently<C: CondowClient, P: Probe + Clone>(
 
     let log_dl_msg_as_dbg = config.log_download_messages_as_debug;
 
-    let downloader = three_concurrently::ThreePartsConcurrently::from_client(
+    let stream = three_concurrently::ThreePartsConcurrently::from_client(
         client,
         location,
         part_requests,
@@ -160,10 +164,10 @@ fn download_chunks_three_concurrently<C: CondowClient, P: Probe + Clone>(
     );
 
     if *config.ensure_active_pull {
-        let active_stream = active_pull(downloader, probe, log_dl_msg_as_dbg);
+        let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
         ChunkStream::from_receiver(active_stream, bytes_hint)
     } else {
-        ChunkStream::from_stream(downloader.boxed(), bytes_hint)
+        ChunkStream::from_three_concurrently(stream, bytes_hint)
     }
 }
 
@@ -174,7 +178,7 @@ fn download_chunks_four_concurrently<C: CondowClient, P: Probe + Clone>(
     probe: P,
     download_span_guard: DownloadSpanGuard,
 ) -> ChunkStream {
-    let bytes_hint = configuration.bytes_hint();
+    let bytes_hint = BytesHint::new_exact(configuration.exact_bytes());
 
     let DownloadConfiguration {
         location,
@@ -185,7 +189,7 @@ fn download_chunks_four_concurrently<C: CondowClient, P: Probe + Clone>(
 
     let log_dl_msg_as_dbg = config.log_download_messages_as_debug;
 
-    let downloader = four_concurrently::FourPartsConcurrently::from_client(
+    let stream = four_concurrently::FourPartsConcurrently::from_client(
         client,
         location,
         part_requests,
@@ -195,9 +199,9 @@ fn download_chunks_four_concurrently<C: CondowClient, P: Probe + Clone>(
     );
 
     if *config.ensure_active_pull {
-        let active_stream = active_pull(downloader, probe, log_dl_msg_as_dbg);
+        let active_stream = active_pull(stream, probe, log_dl_msg_as_dbg);
         ChunkStream::from_receiver(active_stream, bytes_hint)
     } else {
-        ChunkStream::from_stream(downloader.boxed(), bytes_hint)
+        ChunkStream::from_four_concurrently(stream, bytes_hint)
     }
 }

--- a/condow_core/src/machinery/download/concurrent/mod.rs
+++ b/condow_core/src/machinery/download/concurrent/mod.rs
@@ -1,7 +1,5 @@
 //! Components for concurrent downloads
 
-use futures::StreamExt;
-
 use crate::{
     condow_client::CondowClient,
     config::ClientRetryWrapper,

--- a/condow_core/src/machinery/download/concurrent/parallel/worker.rs
+++ b/condow_core/src/machinery/download/concurrent/parallel/worker.rs
@@ -13,12 +13,12 @@ use tokio::sync::mpsc::{self, error::TrySendError, Sender, UnboundedSender};
 use tracing::{debug, debug_span, info, trace, warn, Instrument, Span};
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     config::{ClientRetryWrapper, Config},
     errors::CondowError,
     machinery::{part_request::PartRequest, DownloadSpanGuard},
     probe::Probe,
-    streams::{BytesStream, Chunk, ChunkStreamItem},
+    streams::{Chunk, ChunkStreamItem},
 };
 
 use super::KillSwitch;
@@ -234,7 +234,7 @@ impl<P: Probe + Clone> Drop for DownloaderContext<P> {
 ///
 /// [Bytes]: bytes::bytes
 async fn consume_and_dispatch_bytes<P: Probe + Clone>(
-    mut bytes_stream: BytesStream,
+    mut bytes_stream: ClientBytesStream,
     context: &mut DownloaderContext<P>,
     range_request: PartRequest,
 ) -> Result<(), ()> {

--- a/condow_core/src/machinery/download/concurrent/three_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/three_concurrently.rs
@@ -1,5 +1,6 @@
 //! Download with a maximum concurrncy of 3
 use std::{
+    sync::Arc,
     task::Poll,
     time::{Duration, Instant},
 };
@@ -27,48 +28,48 @@ pin_project! {
     /// parts which have a lower part number (they come in ordered).
     ///
     /// This way there is less entropy in the ordering of the returned chunks.
-    pub struct ThreePartsConcurrently<P: Probe> {
-        active_streams: ActiveStreams<P>,
-        baggage: Baggage<P>,
+    pub struct ThreePartsConcurrently {
+        active_streams: ActiveStreams,
+        baggage: Baggage,
    }
 }
 
-struct Baggage<P: Probe> {
+struct Baggage {
     get_part_stream: Box<
         dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
             + Send
             + 'static,
     >,
     part_requests: Box<dyn Iterator<Item = PartRequest> + Send + 'static>,
-    probe: P,
+    probe: Arc<dyn Probe>,
     download_started_at: Instant,
     log_dl_msg_dbg: LogDownloadMessagesAsDebug,
     download_span_guard: DownloadSpanGuard,
 }
 
-enum ActiveStreams<P: Probe> {
+enum ActiveStreams {
     /// Nothing more to do
     None,
     /// There are 3 or more parts left to download
     ThreeConcurrently {
-        left: PartChunksStream<P>,
-        middle: PartChunksStream<P>,
-        right: PartChunksStream<P>,
+        left: PartChunksStream,
+        middle: PartChunksStream,
+        right: PartChunksStream,
     },
     /// There are exactly 2 parts left to download
     LastTwoConcurrently {
-        left: PartChunksStream<P>,
-        right: PartChunksStream<P>,
+        left: PartChunksStream,
+        right: PartChunksStream,
     },
     /// There is exactly 1 part left to download
-    LastPart(PartChunksStream<P>),
+    LastPart(PartChunksStream),
 }
 
-impl<P: Probe + Clone> ThreePartsConcurrently<P> {
+impl ThreePartsConcurrently {
     pub(crate) fn new<I, L, F>(
         get_part_stream: F,
         mut part_requests: I,
-        probe: P,
+        probe: Arc<dyn Probe>,
         log_dl_msg_dbg: L,
         download_span_guard: DownloadSpanGuard,
     ) -> Self
@@ -159,7 +160,7 @@ impl<P: Probe + Clone> ThreePartsConcurrently<P> {
         }
     }
 
-    pub(crate) fn from_client<C, I, L>(
+    pub(crate) fn from_client<C, I, L, P>(
         client: ClientRetryWrapper<C>,
         location: C::Location,
         part_requests: I,
@@ -171,6 +172,7 @@ impl<P: Probe + Clone> ThreePartsConcurrently<P> {
         I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
         C: CondowClient,
+        P: Probe + Clone,
     {
         let get_part_stream = {
             let probe = probe.clone();
@@ -184,14 +186,14 @@ impl<P: Probe + Clone> ThreePartsConcurrently<P> {
         Self::new(
             get_part_stream,
             part_requests,
-            probe,
+            Arc::new(probe),
             log_dl_msg_dbg,
             download_span_guard,
         )
     }
 }
 
-impl<P: Probe + Clone> Stream for ThreePartsConcurrently<P> {
+impl Stream for ThreePartsConcurrently {
     type Item = ChunkStreamItem;
 
     fn poll_next(
@@ -280,13 +282,13 @@ impl<P: Probe + Clone> Stream for ThreePartsConcurrently<P> {
 ///
 /// Add new parts to the right. If the right slot is not free
 /// move items to the left before adding the new part.
-fn poll_three<P: Probe + Clone>(
-    mut left: PartChunksStream<P>,
-    mut middle: PartChunksStream<P>,
-    mut right: PartChunksStream<P>,
-    baggage: &mut Baggage<P>,
+fn poll_three(
+    mut left: PartChunksStream,
+    mut middle: PartChunksStream,
+    mut right: PartChunksStream,
+    baggage: &mut Baggage,
     cx: &mut std::task::Context<'_>,
-) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams<P>), CondowError> {
+) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams), CondowError> {
     match left.poll_next_unpin(cx) {
         Poll::Ready(Some(Ok(chunk))) => {
             return Ok((
@@ -419,11 +421,11 @@ fn poll_three<P: Probe + Clone>(
 /// poll "left biased" until there is only 1 part left
 ///
 /// There are exactly 2 parts left to download.
-fn poll_last_two<P: Probe + Clone>(
-    mut left: PartChunksStream<P>,
-    mut right: PartChunksStream<P>,
+fn poll_last_two(
+    mut left: PartChunksStream,
+    mut right: PartChunksStream,
     cx: &mut std::task::Context<'_>,
-) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams<P>), CondowError> {
+) -> Result<(Poll<Option<ChunkStreamItem>>, ActiveStreams), CondowError> {
     match left.poll_next_unpin(cx) {
         Poll::Ready(Some(Ok(chunk))) => {
             return Ok((

--- a/condow_core/src/machinery/download/concurrent/three_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/three_concurrently.rs
@@ -9,13 +9,13 @@ use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use pin_project_lite::pin_project;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     config::LogDownloadMessagesAsDebug,
     errors::CondowError,
     machinery::{download::PartChunksStream, part_request::PartRequest, DownloadSpanGuard},
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::{BytesStream, ChunkStreamItem},
+    streams::ChunkStreamItem,
     InclusiveRange,
 };
 
@@ -36,7 +36,7 @@ pin_project! {
 
 struct Baggage {
     get_part_stream: Box<
-        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     >,
@@ -76,7 +76,7 @@ impl ThreePartsConcurrently {
     where
         I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
-        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     {

--- a/condow_core/src/machinery/download/concurrent/two_concurrently.rs
+++ b/condow_core/src/machinery/download/concurrent/two_concurrently.rs
@@ -9,13 +9,13 @@ use futures::{future::BoxFuture, FutureExt, Stream, StreamExt};
 use pin_project_lite::pin_project;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     config::LogDownloadMessagesAsDebug,
     errors::CondowError,
     machinery::{download::PartChunksStream, part_request::PartRequest, DownloadSpanGuard},
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::{BytesStream, ChunkStreamItem},
+    streams::ChunkStreamItem,
     InclusiveRange,
 };
 
@@ -36,7 +36,7 @@ pin_project! {
 
 struct Baggage {
     get_part_stream: Box<
-        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     >,
@@ -70,7 +70,7 @@ impl TwoPartsConcurrently {
     where
         I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
-        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     {

--- a/condow_core/src/machinery/download/mod.rs
+++ b/condow_core/src/machinery/download/mod.rs
@@ -7,10 +7,13 @@ use tokio::sync::mpsc::{self, UnboundedSender};
 
 use crate::{config::LogDownloadMessagesAsDebug, errors::CondowError, probe::Probe};
 
-pub(crate) use concurrent::{download_bytes_concurrently, download_chunks_concurrently};
+pub(crate) use concurrent::{
+    download_bytes_concurrently, download_chunks_concurrently, FourPartsConcurrently,
+    ThreePartsConcurrently, TwoPartsConcurrently,
+};
 pub(crate) use part_chunks_stream::PartChunksStream;
 pub(crate) use sequential::{
-    download_bytes_sequentially, download_chunks_sequentially, PartsBytesStream,
+    download_bytes_sequentially, download_chunks_sequentially, DownloadPartsSeq, PartsBytesStream,
 };
 
 mod concurrent;

--- a/condow_core/src/machinery/download/sequential/mod.rs
+++ b/condow_core/src/machinery/download/sequential/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn download_chunks_sequentially<C: CondowClient, P: Probe + Clone>(
 
     if *ensure_active_pull {
         let active_stream = active_pull(stream, probe, log_dl_msg_dbg);
-        ChunkStream::from_receiver(active_stream, bytes_hint)
+        ChunkStream::from_active_stream(active_stream, bytes_hint)
     } else {
         ChunkStream::from_download_parts_seq(stream, bytes_hint)
     }
@@ -68,7 +68,7 @@ pub(crate) fn download_bytes_sequentially<C: CondowClient, P: Probe + Clone>(
 
     if *ensure_active_pull {
         let active_stream = active_pull(stream, probe, log_dl_msg_dbg);
-        BytesStream::new_tokio_receiver(active_stream, BytesHint::new_exact(exact_bytes))
+        BytesStream::new_active_stream(active_stream, BytesHint::new_exact(exact_bytes))
     } else {
         BytesStream::new_parts_bytes_stream(stream)
     }

--- a/condow_core/src/machinery/download/sequential/mod.rs
+++ b/condow_core/src/machinery/download/sequential/mod.rs
@@ -1,6 +1,4 @@
 //! Components for sequential downloads
-use futures::StreamExt;
-
 use crate::{
     condow_client::CondowClient,
     machinery::{configure_download::DownloadConfiguration, DownloadSpanGuard},

--- a/condow_core/src/machinery/download/sequential/mod.rs
+++ b/condow_core/src/machinery/download/sequential/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::active_pull;
 
-use parts_bytes_stream::PartsBytesStream;
+pub(crate) use parts_bytes_stream::PartsBytesStream;
 
 pub mod part_bytes_stream;
 pub mod parts_bytes_stream;
@@ -84,13 +84,13 @@ mod download_parts_seq {
     use pin_project_lite::pin_project;
 
     use crate::{
-        condow_client::CondowClient,
+        condow_client::{ClientBytesStream, CondowClient},
         config::LogDownloadMessagesAsDebug,
         errors::CondowError,
         machinery::{download::PartChunksStream, part_request::PartRequest, DownloadSpanGuard},
         probe::Probe,
         retry::ClientRetryWrapper,
-        streams::{BytesStream, ChunkStreamItem},
+        streams::ChunkStreamItem,
         InclusiveRange,
     };
     /// Internal state of the stream.
@@ -106,7 +106,7 @@ mod download_parts_seq {
         ///
         /// Parts are downloaded sequentially
         pub (crate) struct DownloadPartsSeq {
-            get_part_stream: Box<dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>> + Send + 'static>,
+            get_part_stream: Box<dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>> + Send + 'static>,
             part_requests: Box<dyn Iterator<Item=PartRequest> + Send + 'static>,
             state: State,
             probe: Arc<dyn Probe>,
@@ -127,7 +127,7 @@ mod download_parts_seq {
         where
             I: Iterator<Item = PartRequest> + Send + 'static,
             L: Into<LogDownloadMessagesAsDebug>,
-            F: Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+            F: Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
                 + Send
                 + 'static,
         {

--- a/condow_core/src/machinery/download/sequential/parts_bytes_stream.rs
+++ b/condow_core/src/machinery/download/sequential/parts_bytes_stream.rs
@@ -11,15 +11,15 @@ use pin_project_lite::pin_project;
 use tracing::Span;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     config::LogDownloadMessagesAsDebug,
     errors::CondowError,
     machinery::{
-        download::sequential::part_bytes_stream::PartBytesStream, part_request::PartRequest,
+        download::sequential::part_bytes_stream::PartBytesStream, part_request::PartRequestIterator,
     },
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::{BytesStream, BytesStreamItem},
+    streams::BytesStreamItem,
     InclusiveRange,
 };
 
@@ -36,32 +36,33 @@ pin_project! {
     ///
     /// Parts are downloaded sequentially
     pub struct PartsBytesStream {
-        get_part_stream: Box<dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>> + Send + 'static>,
-        part_requests: Box<dyn Iterator<Item=PartRequest> + Send + 'static>,
+        get_part_stream: Box<dyn Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>> + Send + 'static>,
+        part_requests: PartRequestIterator,
         state: State,
         probe: Arc<dyn Probe>,
         download_started_at: Instant,
         log_dl_msg_dbg: LogDownloadMessagesAsDebug,
         parent_span: Arc<Span>,
+        bytes_left: u64,
     }
 }
 
 impl PartsBytesStream {
-    pub fn new<I, L, F>(
+    pub fn new<L, F>(
         get_part_stream: F,
-        mut part_requests: I,
+        mut part_requests: PartRequestIterator,
         probe: Arc<dyn Probe>,
         log_dl_msg_dbg: L,
         parent_span: Arc<Span>,
     ) -> Self
     where
-        I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
-        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<BytesStream, CondowError>>
+        F: Fn(InclusiveRange) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>>
             + Send
             + 'static,
     {
         let log_dl_msg_dbg = log_dl_msg_dbg.into();
+        let bytes_left = part_requests.exact_bytes_left();
 
         if let Some(part_request) = part_requests.next() {
             let stream =
@@ -69,12 +70,13 @@ impl PartsBytesStream {
 
             Self {
                 get_part_stream: Box::new(get_part_stream),
-                part_requests: Box::new(part_requests),
+                part_requests,
                 state: State::Streaming(stream),
                 probe,
                 download_started_at: Instant::now(),
                 log_dl_msg_dbg,
                 parent_span,
+                bytes_left,
             }
         } else {
             probe.download_completed(Duration::ZERO);
@@ -83,26 +85,26 @@ impl PartsBytesStream {
 
             Self {
                 get_part_stream: Box::new(get_part_stream),
-                part_requests: Box::new(part_requests),
+                part_requests,
                 state: State::Finished,
                 probe,
                 download_started_at: Instant::now(),
                 log_dl_msg_dbg,
                 parent_span,
+                bytes_left,
             }
         }
     }
 
-    pub(crate) fn from_client<C, I, L, P>(
+    pub(crate) fn from_client<C, L, P>(
         client: ClientRetryWrapper<C>,
         location: C::Location,
-        part_requests: I,
+        part_requests: PartRequestIterator,
         probe: P,
         log_dl_msg_dbg: L,
         parent_span: Arc<Span>,
     ) -> Self
     where
-        I: Iterator<Item = PartRequest> + Send + 'static,
         L: Into<LogDownloadMessagesAsDebug>,
         C: CondowClient,
         P: Probe + Clone,
@@ -124,6 +126,15 @@ impl PartsBytesStream {
             parent_span,
         )
     }
+
+    pub fn exact_bytes(mut self, exact_bytes_left: u64) -> Self {
+        self.bytes_left = exact_bytes_left;
+        self
+    }
+
+    // pub fn bytes_hint(&self) -> BytesHint {
+    //          BytesHint::new_exact(self.bytes_left)
+    // }
 }
 
 impl Stream for PartsBytesStream {

--- a/condow_core/src/machinery/download/sequential/parts_bytes_stream.rs
+++ b/condow_core/src/machinery/download/sequential/parts_bytes_stream.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     probe::Probe,
     retry::ClientRetryWrapper,
-    streams::BytesStreamItem,
+    streams::{BytesHint, BytesStreamItem},
     InclusiveRange,
 };
 
@@ -132,9 +132,9 @@ impl PartsBytesStream {
         self
     }
 
-    // pub fn bytes_hint(&self) -> BytesHint {
-    //          BytesHint::new_exact(self.bytes_left)
-    // }
+    pub fn bytes_hint(&self) -> BytesHint {
+        BytesHint::new_exact(self.bytes_left)
+    }
 }
 
 impl Stream for PartsBytesStream {

--- a/condow_core/src/machinery/mod.rs
+++ b/condow_core/src/machinery/mod.rs
@@ -12,7 +12,7 @@ use crate::Probe;
 use crate::{DownloadRange, InclusiveRange};
 
 mod configure_download;
-mod download;
+pub(crate) mod download;
 mod part_request;
 
 pub(crate) async fn download_chunks<C: CondowClient, DR: Into<DownloadRange>, P: Probe + Clone>(

--- a/condow_core/src/machinery/part_request.rs
+++ b/condow_core/src/machinery/part_request.rs
@@ -74,7 +74,11 @@ impl PartRequestIterator {
     /// Returns a hint for the bytes which are still to be
     /// delivered by the rmaining [PartRequest]s
     pub fn bytes_hint(&self) -> BytesHint {
-        BytesHint::new_exact(self.bytes_left)
+        BytesHint::new_exact(self.exact_bytes_left())
+    }
+
+    pub fn exact_bytes_left(&self) -> u64 {
+        self.bytes_left
     }
 
     /// Turns this iterator into a [Stream]

--- a/condow_core/src/machinery/part_request.rs
+++ b/condow_core/src/machinery/part_request.rs
@@ -1,6 +1,6 @@
 use futures::Stream;
 
-use crate::{streams::BytesHint, InclusiveRange};
+use crate::{InclusiveRange};
 
 /// A request to download a part.
 ///
@@ -69,12 +69,6 @@ impl PartRequestIterator {
     /// Returns the number of parts left
     pub fn parts_hint(&self) -> u64 {
         self.parts_left
-    }
-
-    /// Returns a hint for the bytes which are still to be
-    /// delivered by the rmaining [PartRequest]s
-    pub fn bytes_hint(&self) -> BytesHint {
-        BytesHint::new_exact(self.exact_bytes_left())
     }
 
     pub fn exact_bytes_left(&self) -> u64 {

--- a/condow_core/src/machinery/part_request.rs
+++ b/condow_core/src/machinery/part_request.rs
@@ -1,6 +1,6 @@
 use futures::Stream;
 
-use crate::{InclusiveRange};
+use crate::InclusiveRange;
 
 /// A request to download a part.
 ///

--- a/condow_core/src/probe.rs
+++ b/condow_core/src/probe.rs
@@ -31,12 +31,8 @@
 //!
 //! // Methods of Probe have noop default implementations
 //! impl Probe for MyProbe {
-//!     fn chunk_completed(&self,
-//!         _part_index: u64,
-//!         _chunk_index: usize,
-//!         n_bytes: usize,
-//!         _time: Duration) {
-//!         self.bytes_received.fetch_add(n_bytes, Ordering::SeqCst);
+//!     fn part_completed(&self, _part_index: u64, _n_chunks: usize, n_bytes: u64, _time: Duration) {
+//!         self.bytes_received.fetch_add(n_bytes as usize, Ordering::SeqCst);
 //!     }
 //! }
 //!
@@ -74,11 +70,8 @@
 //!
 //! // Methods of Probe have noop default implementations
 //! impl Probe for MyProbe {
-//!     fn chunk_received(&self,
-//!         _part_index: u64,
-//!         _chunk_index: usize,
-//!         n_bytes: usize) {
-//!         self.bytes_received.fetch_add(n_bytes, Ordering::SeqCst);
+//!     fn part_completed(&self, _part_index: u64, _n_chunks: usize, n_bytes: u64, _time: Duration) {
+//!         self.bytes_received.fetch_add(n_bytes as usize, Ordering::SeqCst);
 //!     }
 //! }
 //!

--- a/condow_core/src/retry/mod.rs
+++ b/condow_core/src/retry/mod.rs
@@ -5,10 +5,9 @@ use futures::Future;
 use tracing::warn;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     errors::CondowError,
     probe::Probe,
-    streams::{BytesHint, BytesStream},
     InclusiveRange,
 };
 
@@ -384,7 +383,7 @@ where
         location: C::Location,
         range: InclusiveRange,
         probe: P,
-    ) -> impl Future<Output = Result<BytesStream, CondowError>> + Send + 'static {
+    ) -> impl Future<Output = Result<ClientBytesStream, CondowError>> + Send + 'static {
         //debug!("retry client - downloading part");
 
         let inner = Arc::clone(&self.inner);
@@ -394,7 +393,7 @@ where
                 let stream =
                     RetryPartStream::from_client(client, location, range, config.clone(), probe)
                         .await?;
-                Ok(BytesStream::new(stream, BytesHint::new_exact(range.len())))
+                Ok(ClientBytesStream::new(stream, range.len()))
             } else {
                 Ok(client.download(location, range).await?)
             }

--- a/condow_core/src/retry/retry_stream.rs
+++ b/condow_core/src/retry/retry_stream.rs
@@ -5,16 +5,16 @@ use pin_project_lite::pin_project;
 use tracing::warn;
 
 use crate::{
-    condow_client::CondowClient,
+    condow_client::{ClientBytesStream, CondowClient},
     errors::CondowError,
     probe::Probe,
-    streams::{BytesStream, BytesStreamItem},
+    streams::BytesStreamItem,
     InclusiveRange,
 };
 
 use super::RetryConfig;
 
-type GetStreamFut = BoxFuture<'static, Result<BytesStream, CondowError>>;
+type GetStreamFut = BoxFuture<'static, Result<ClientBytesStream, CondowError>>;
 
 type GetStreamFn = Arc<dyn Fn(InclusiveRange) -> GetStreamFut + Send + Sync + 'static>;
 
@@ -107,8 +107,8 @@ where
 
 enum RetryResumePartStreamState {
     GettingStream(GetStreamFut, usize),
-    StreamingAfterResume(BytesStream, usize),
-    Streaming(BytesStream),
+    StreamingAfterResume(ClientBytesStream, usize),
+    Streaming(ClientBytesStream),
     Finished,
 }
 
@@ -129,7 +129,7 @@ where
 {
     pub fn new(
         initial_range: InclusiveRange,
-        bytes_stream: BytesStream,
+        bytes_stream: ClientBytesStream,
         get_stream_fn: GetStreamFn,
         config: RetryConfig,
         probe: Arc<P>,

--- a/condow_core/src/retry/tests.rs
+++ b/condow_core/src/retry/tests.rs
@@ -1226,11 +1226,12 @@ mod retry_download_get_stream {
                 &self,
                 _location: Self::Location,
                 _range: InclusiveRange,
-            ) -> futures::future::BoxFuture<'static, Result<BytesStream, CondowError>> {
+            ) -> futures::future::BoxFuture<'static, Result<ClientBytesStream, CondowError>>
+            {
                 let mut fails = self.fails_reversed.lock().unwrap();
 
                 if fails.is_empty() {
-                    futures::future::ready(Ok(BytesStream::empty())).boxed()
+                    futures::future::ready(Ok(ClientBytesStream::empty())).boxed()
                 } else {
                     let err = CondowError::from(fails.pop().unwrap());
                     futures::future::ready(Err(err)).boxed()
@@ -1471,7 +1472,8 @@ mod retry_get_size {
                 &self,
                 _location: Self::Location,
                 _range: InclusiveRange,
-            ) -> futures::future::BoxFuture<'static, Result<BytesStream, CondowError>> {
+            ) -> futures::future::BoxFuture<'static, Result<ClientBytesStream, CondowError>>
+            {
                 unimplemented!()
             }
         }

--- a/condow_core/src/streams/bytes_stream.rs
+++ b/condow_core/src/streams/bytes_stream.rs
@@ -229,7 +229,7 @@ impl Stream for SourceFlavour {
         match this {
             SourceFlavourProj::DynStream { mut stream } => stream.as_mut().poll_next(cx),
             SourceFlavourProj::PartsBytesStream { stream } => match stream.poll_next(cx) {
-                Poll::Ready(Some(res)) => Poll::Ready(Some(res.map(|bytes| bytes))),
+                Poll::Ready(Some(res)) => Poll::Ready(Some(res)),
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,
             },

--- a/condow_core/src/streams/bytes_stream.rs
+++ b/condow_core/src/streams/bytes_stream.rs
@@ -13,7 +13,10 @@ use futures::{
 use pin_project_lite::pin_project;
 use tokio::sync::mpsc as tokio_mpsc;
 
-use crate::{errors::CondowError, streams::BytesHint, streams::OrderedChunkStream};
+use crate::{
+    errors::CondowError, machinery::download::PartsBytesStream, streams::BytesHint,
+    streams::OrderedChunkStream,
+};
 
 /// Item of a [BytesStream]
 pub type BytesStreamItem = Result<Bytes, CondowError>;
@@ -117,10 +120,6 @@ impl BytesStream {
         Self::once(Ok(bytes))
     }
 
-    pub fn bytes_hint(&self) -> BytesHint {
-        self.bytes_hint
-    }
-
     pub fn into_io_stream(self) -> impl Stream<Item = Result<Bytes, io::Error>> {
         self.map_err(From::from)
     }
@@ -197,6 +196,10 @@ impl BytesStream {
     pub async fn count_bytes(self) -> Result<u64, CondowError> {
         self.try_fold(0u64, |acc, chunk| future::ok(acc + chunk.len() as u64))
             .await
+    }
+
+    pub fn bytes_hint(&self) -> BytesHint {
+        self.bytes_hint
     }
 }
 

--- a/condow_core/src/streams/bytes_stream.rs
+++ b/condow_core/src/streams/bytes_stream.rs
@@ -24,8 +24,7 @@ pub type BytesStreamItem = Result<Bytes, CondowError>;
 pin_project! {
     /// A stream of [Bytes] (chunks) where there can be an error for each chunk of bytes
     ///
-    /// This stream is fused. It will always return `None` after `None` or an error was
-    /// returned.
+    /// This stream is NOT fused.
     pub struct BytesStream {
         #[pin]
         source: SourceFlavour,

--- a/condow_core/src/streams/ordered_chunk_stream.rs
+++ b/condow_core/src/streams/ordered_chunk_stream.rs
@@ -311,7 +311,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -344,7 +344,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 let chunk = Chunk {
                     part_index: 0,
@@ -354,7 +354,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -387,7 +387,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 0,
@@ -396,7 +396,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -429,7 +429,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -438,7 +438,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 0,
@@ -447,7 +447,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -456,7 +456,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -489,7 +489,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 0,
@@ -498,7 +498,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -507,7 +507,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -516,7 +516,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -549,7 +549,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 0,
@@ -558,7 +558,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -567,7 +567,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -576,7 +576,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -609,7 +609,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 0,
@@ -618,7 +618,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -651,7 +651,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -660,7 +660,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 0,
@@ -669,7 +669,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -678,7 +678,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -711,7 +711,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 0,
@@ -720,7 +720,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -729,7 +729,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -738,7 +738,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 
@@ -771,7 +771,7 @@ mod tests {
                     bytes: Bytes::from_static(&[3]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 0,
@@ -780,7 +780,7 @@ mod tests {
                     bytes: Bytes::from_static(&[1]),
                     bytes_left: 1,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 0,
                     chunk_index: 1,
@@ -789,7 +789,7 @@ mod tests {
                     bytes: Bytes::from_static(&[2]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
                 let chunk = Chunk {
                     part_index: 1,
                     chunk_index: 1,
@@ -798,7 +798,7 @@ mod tests {
                     bytes: Bytes::from_static(&[4]),
                     bytes_left: 0,
                 };
-                tx.send(Ok(chunk)).unwrap();
+                tx.consume(Ok(chunk)).unwrap();
 
                 drop(tx); // Close the channel! Otherwise the stream does not end!
 

--- a/condow_core/src/streams/ordered_chunk_stream.rs
+++ b/condow_core/src/streams/ordered_chunk_stream.rs
@@ -140,7 +140,7 @@ impl OrderedChunkStream {
     }
 
     pub fn into_bytes_stream(self) -> BytesStream {
-        BytesStream::from_chunk_stream(self)
+        BytesStream::new_chunk_stream(self)
     }
 
     /// Counts the number of bytes downloaded

--- a/condow_core/src/test_utils.rs
+++ b/condow_core/src/test_utils.rs
@@ -293,7 +293,7 @@ pub fn create_chunk_stream(
 
         let part = &mut parts[n];
         let chunk = part.remove(0);
-        let _ = tx.send(chunk);
+        let _ = tx.consume(chunk);
         if part.is_empty() {
             parts.remove(n);
         }
@@ -386,7 +386,7 @@ pub fn create_chunk_stream_with_err(
     let mut err_sent = chunks_left_until_err == 0;
     loop {
         if chunks_left_until_err == 0 {
-            let _ = tx.send(Err(CondowError::new_other("forced stream error")));
+            let _ = tx.consume(Err(CondowError::new_other("forced stream error")));
             err_sent = true;
             break;
         }
@@ -395,7 +395,7 @@ pub fn create_chunk_stream_with_err(
 
         let part = &mut parts[n];
         let chunk = part.remove(0);
-        let _ = tx.send(chunk);
+        let _ = tx.consume(chunk);
         if part.is_empty() {
             parts.remove(n);
         }
@@ -406,7 +406,7 @@ pub fn create_chunk_stream_with_err(
     }
 
     if !err_sent {
-        let _ = tx.send(Err(CondowError::new_other("forced stream error after end")));
+        let _ = tx.consume(Err(CondowError::new_other("forced stream error after end")));
     }
 
     (chunk_stream, values)
@@ -579,7 +579,7 @@ fn make_a_stream(
                     if let Some(pattern) = pattern {
                         (chunk_index, pattern)
                     } else {
-                        let _ = tx.send(Err(CondowError::new_other("test error")));
+                        let _ = tx.consume(Err(CondowError::new_other("test error")));
                         break;
                     }
                 } else {
@@ -599,7 +599,7 @@ fn make_a_stream(
                 bytes_left,
             };
 
-            let _ = tx.send(Ok(chunk));
+            let _ = tx.consume(Ok(chunk));
 
             start = end_excl;
         }

--- a/condow_core/src/test_utils.rs
+++ b/condow_core/src/test_utils.rs
@@ -12,7 +12,7 @@ use rand::{prelude::SliceRandom, rngs::OsRng, Rng};
 use tokio::time;
 
 use crate::{
-    condow_client::{CondowClient, IgnoreLocation},
+    condow_client::{ClientBytesStream, CondowClient, IgnoreLocation},
     config::Config,
     errors::CondowError,
     request::{Params, RequestAdapter},
@@ -26,7 +26,6 @@ use self::stream_penderizer::{Penderizer, PenderizerModule};
 pub struct TestCondowClient {
     pub data: Arc<Vec<u8>>,
     pub max_jitter_ms: usize,
-    pub include_size_hint: bool,
     pub max_chunk_size: usize,
     pub pending_on_stream_module: Option<PenderizerModule>,
     pub pending_on_requests_module: Option<Mutex<PenderizerModule>>,
@@ -38,7 +37,6 @@ impl TestCondowClient {
         Self {
             data: Arc::new(create_test_data()),
             max_jitter_ms: 0,
-            include_size_hint: true,
             max_chunk_size: 10,
             pending_on_stream_module: None,
             pending_on_requests_module: None,
@@ -68,11 +66,6 @@ impl TestCondowClient {
         self
     }
 
-    pub fn include_size_hint(mut self, include_size_hint: bool) -> Self {
-        self.include_size_hint = include_size_hint;
-        self
-    }
-
     pub fn data(&self) -> Arc<Vec<u8>> {
         Arc::clone(&self.data)
     }
@@ -94,7 +87,6 @@ impl Clone for TestCondowClient {
         Self {
             data: Arc::clone(&self.data),
             max_jitter_ms: self.max_jitter_ms,
-            include_size_hint: self.include_size_hint,
             max_chunk_size: self.max_chunk_size,
             pending_on_stream_module: self.pending_on_stream_module,
             pending_on_requests_module,
@@ -124,7 +116,10 @@ impl CondowClient for TestCondowClient {
         &self,
         _location: Self::Location,
         range: InclusiveRange,
-    ) -> BoxFuture<'static, Result<crate::streams::BytesStream, crate::errors::CondowError>> {
+    ) -> BoxFuture<
+        'static,
+        Result<crate::condow_client::ClientBytesStream, crate::errors::CondowError>,
+    > {
         let should_be_pending = if let Some(module) = &self.pending_on_requests_module {
             module.lock().unwrap().return_pending()
         } else {
@@ -153,11 +148,7 @@ impl CondowClient for TestCondowClient {
 
             let slice = &me.data[range];
 
-            let bytes_hint = if me.include_size_hint {
-                BytesHint::new_exact(slice.len() as u64)
-            } else {
-                BytesHint::new_no_hint()
-            };
+            let exact_bytes_left = slice.len() as u64;
 
             let iter = slice
                 .chunks(me.max_chunk_size)
@@ -175,12 +166,13 @@ impl CondowClient for TestCondowClient {
                 bytes
             });
 
-            let stream: BytesStream = if let Some(pending_module) = me.pending_on_stream_module {
-                let stream_with_pending = Penderizer::new(stream, pending_module);
-                BytesStream::new(stream_with_pending.boxed(), bytes_hint)
-            } else {
-                BytesStream::new(stream.boxed(), bytes_hint)
-            };
+            let stream: ClientBytesStream =
+                if let Some(pending_module) = me.pending_on_stream_module {
+                    let stream_with_pending = Penderizer::new(stream, pending_module);
+                    ClientBytesStream::new(stream_with_pending.boxed(), exact_bytes_left)
+                } else {
+                    ClientBytesStream::new(stream.boxed(), exact_bytes_left)
+                };
 
             Ok(stream)
         }

--- a/condow_fs/Cargo.toml
+++ b/condow_fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_fs"
-version = "0.19.0"
+version = "0.20.0-alpha.1"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -11,7 +11,7 @@ repository = "https://github.com/chridou/condow"
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "^0.18.0", path = "../condow_core"}
+condow_core = { version = "^0.19.0-alpha.1", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"

--- a/condow_fs/src/lib.rs
+++ b/condow_fs/src/lib.rs
@@ -28,7 +28,10 @@ use futures::future::BoxFuture;
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
-use condow_core::{condow_client::CondowClient, errors::CondowError, streams::BytesStream};
+use condow_core::{
+    condow_client::{ClientBytesStream, CondowClient},
+    errors::CondowError,
+};
 
 pub use condow_core::*;
 
@@ -60,7 +63,7 @@ impl CondowClient for FsClient {
         &self,
         location: Self::Location,
         range: InclusiveRange,
-    ) -> BoxFuture<'static, Result<BytesStream, CondowError>> {
+    ) -> BoxFuture<'static, Result<ClientBytesStream, CondowError>> {
         let f = async move {
             let bytes = {
                 let mut file = fs::File::open(location.as_str()).await?;
@@ -90,7 +93,7 @@ impl CondowClient for FsClient {
 
             let bytes = Bytes::from(bytes);
 
-            Ok(BytesStream::once_ok(bytes))
+            Ok(ClientBytesStream::once_ok(bytes))
         };
 
         Box::pin(f)

--- a/condow_http/Cargo.toml
+++ b/condow_http/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/chridou/condow"
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "^0.18.0", path = "../condow_core"}
+condow_core = { version = "^0.19.0-alpha.1", path = "../condow_core"}
 anyhow = "1.0"
 bytes = "1"
 futures = "0.3"

--- a/condow_rusoto/Cargo.toml
+++ b/condow_rusoto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condow_rusoto"
-version = "0.19.0"
+version = "0.20.0-alpha.1"
 authors = ["Christian Douven <chridou@users.noreply.github.com>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"
@@ -12,7 +12,7 @@ keywords = [ "AWS", "S3", "download", "parallel", "rusoto"]
 edition = "2021"
 
 [dependencies]
-condow_core = { version = "^0.18.0", path = "../condow_core"}
+condow_core = { version = "^0.19.0-alpha.1", path = "../condow_core"}
 
 futures = "0.3"
 anyhow = "1.0"


### PR DESCRIPTION
* Streams are statically dispatched via enums
* Actively pulling a stream uses a buffer 
* Client became on own bytes stream